### PR TITLE
feat(private-bond): added benchmark file

### DIFF
--- a/pocs/private-bond/BENCHMARK.md
+++ b/pocs/private-bond/BENCHMARK.md
@@ -1,0 +1,132 @@
+# Private Bond Benchmarks
+
+Comparison of three implementation approaches.
+
+> Note: this are not precise benchmarks and should not be seen as a point of reference. These are estimates gathered from documentation and code available, that we could have run.
+
+## Gas Costs
+
+### Custom UTXO
+
+**PoC not directly measurable** - Our PoC uses UltraPlonk and a trivial Merkle tree implementation that's too costly for production. However, we can use [Railgun](https://docs.railgun.org/) gas costs as a production reference for a mature custom UTXO system with optimized Groth16 proofs.
+
+**Railgun Production Reference** (from [Railgun-Privacy/contract](https://github.com/Railgun-Privacy/contract)):
+
+| Operation           | Min Gas | Max Gas   | Avg Gas    | Notes                          |
+| ------------------- | ------- | --------- | ---------- | ------------------------------ |
+| Shield (deposit)    | 52,598  | 2,209,668 | **~1.19M** | Move tokens into privacy pool  |
+| Transact (transfer) | 32,118  | 1,183,520 | **~1.07M** | Private transfer between users |
+
+See also [Paladin](https://www.paladinprivacy.org/) for enterprise-focused custom UTXO patterns.
+
+### Aztec L2
+
+**Not measurable**: Aztec execution layer is scheduled for later in 2026, only at that moment we will be able to test the fee structure of the network.
+
+### Zama FHE
+
+```bash
+cd pocs/private-bond/fhe && REPORT_GAS=true npm run test:sepolia
+```
+
+**Measured on Sepolia**:
+
+| Operation           | FHE Ops | Actual Gas |
+| ------------------- | ------- | ---------- |
+| Deployment          | N/A     | ~1.66M     |
+| Transfer            | 4       | ~330K      |
+| addToWhitelist      | 0       | ~47K       |
+| removeFromWhitelist | 0       | ~26K       |
+| transferOwnership   | 0       | ~34K       |
+
+**Not yet measured**: TransferFrom, Approve, Redeem (tests pending).
+
+Gas is on-chain only; FHE computation is off-chain (see Latency).
+
+---
+
+## Computation Latency
+
+### Custom UTXO
+
+**Not directly measurable** - As stated above.
+Proxy: [Semaphore V4 - Benchmarks](https://docs.semaphore.pse.dev/benchmarks) with similar circuit complexity (Merkle Tree inclusion proof + nullifier) with a Groth16 prover.
+
+| Environment | Est. Proving Time |
+| ----------- | ----------------- |
+| Browser     | 5-30s             |
+| Node.js     | 2-10s             |
+| Server      | <1-3s             |
+
+### Aztec L2
+
+**Measured on Local Aztec Sandbox**:
+
+Average proving time: **~9.8 seconds** per transaction
+
+| Operation            | Witness Gen (ms) | IVC Proof (ms) | Total (ms)    |
+| -------------------- | ---------------- | -------------- | ------------- |
+| Deployment           | 1,500            | 8,502          | 10,002        |
+| Whitelist Add        | 857-1,488        | 7,222-7,470    | 8,327-8,709   |
+| Private Distribution | 1,231-1,240      | 8,999-9,145    | 10,231-10,385 |
+| Private Transfer     | 1,357            | 9,836          | 11,194        |
+| Redeem               | 1,327-1,347      | 8,268-8,377    | 9,615-9,704   |
+
+Machine: MacBook Pro M1 Pro - 16GB
+Source: [privacy-l2/contracts/logs/test-logs.txt](./privacy-l2/contracts/logs/test-logs.txt)
+
+### Zama FHE
+
+**Estimated** from operation counts (~10-20ms per FHE op):
+
+| Operation    | FHE Ops | Latency (CPU) | Latency (GPU, 2026) |
+| ------------ | ------- | ------------- | ------------------- |
+| Transfer     | 4       | ~40-80ms      | ~1.6-3.2ms          |
+| TransferFrom | 7       | ~70-140ms     | ~2.8-5.6ms          |
+| Redeem       | 3       | ~30-60ms      | ~1.2-2.4ms          |
+
+Source: [Zama fhEVM paper](https://github.com/zama-ai/fhevm/blob/main/fhevm-whitepaper.pdf)
+
+---
+
+## Throughput (TPS)
+
+| Approach    | Current (PoC) | Production Potential | Bottleneck                    |
+| ----------- | ------------- | -------------------- | ----------------------------- |
+| Custom UTXO | N/A           | L1: ~15-30 TPS       | PoC: Centralized issuer relay |
+|             |               | L2: ~2,000+ TPS      | Prod: Network + gas costs     |
+| Aztec L2    | N/A           | unknown              | Sequencer + L1 batching       |
+| Zama FHE    | N/A           | unknown              | Coprocessor network           |
+
+_Note on Zama: TPS announces a network-wide TPS of 500-1000 (shared across all fhEVM apps)._
+
+---
+
+## Privacy Comparison
+
+| Approach    | Hidden                        | Public                                          |
+| ----------- | ----------------------------- | ----------------------------------------------- |
+| Custom UTXO | Amounts, balances, tx linkage | Merkle root updates, nullifiers, tx count       |
+| Aztec L2    | Amounts, balances             | Addresses (via whitelist), L1 state commitments |
+| Zama FHE    | Amounts, balances             | Addresses, tx existence                         |
+
+---
+
+## Trade-offs
+
+| Approach    | Strengths                                          | Weaknesses                                                                                    |
+| ----------- | -------------------------------------------------- | --------------------------------------------------------------------------------------------- |
+| Custom UTXO | Full unlinkability, proven model, full audit trail | Centralized issuer, custom implementation                                                     |
+| Aztec L2    | Native privacy L2, composable, scalable            | Not live, unknown costs and TPS                                                               |
+| Zama FHE    | EVM-compatible, devx                               | Shared network TPS (500-1000 across all apps), addresses public, threshold network dependency |
+
+---
+
+## Sources
+
+- [Railgun Documentation](https://docs.railgun.org/)
+- [Railgun Gas Report](./railgun-gas-report.txt) - Hardhat gas benchmarks for production Railgun contracts
+- [Semaphore V4 Benchmarks](https://docs.semaphore.pse.dev/benchmarks)
+- [Aztec Documentation](https://docs.aztec.network/)
+- [Zama fhEVM Documentation](https://docs.zama.ai/fhevm)
+- [Zama Protocol Litepaper](https://www.zama.ai/)

--- a/pocs/private-bond/privacy-l2/logs/test-logs.txt
+++ b/pocs/private-bond/privacy-l2/logs/test-logs.txt
@@ -1,0 +1,416 @@
+==============================================================
+  PRIVATE BONDS ON AZTEC L2 - FULL LIFECYCLE DEMO
+==============================================================
+
+Actors:
+  - Issuer (test0): Bond Issuer
+  - Investor A (test1): Institutional Investor
+  - Investor B (test2): Institutional Investor
+
+==============================================================
+PHASE 1: CONTRACT DEPLOYMENT & ISSUANCE
+==============================================================
+
+Issuer deploys PrivateBonds contract...
+  - Total supply: 1,000,000 (FIXED forever)
+  - Maturity: 0 (immediate for demo)
+
+[13:29:43.751] INFO: pxe:data:lmdb Creating pxe_data data store at directory /Users/yanismeziane/.aztec/wallet/pxe/pxe_data with map size 134217728 KB (LMDB v2)
+[13:29:43.754] INFO: pxe:data:lmdb Starting data store with maxReaders 16
+Using Fee Juice for fee payment with the balance of account 0x2974756c17646ca139f79b5710b6aee11e2621ce65c882ffd593cfde58d94072
+[13:29:44.125] INFO: pxe:service Started PXE connected to chain 31337 version 845231672
+[13:29:44.126] INFO: kv-store:lmdb-v2 Starting data store with maxReaders 16
+[13:29:44.137] INFO: wallet Using wallet with address 0x2974756c17646ca139f79b5710b6aee11e2621ce65c882ffd593cfde58d94072
+[13:29:44.801] INFO: pxe:service Added contract PrivateBonds at 0x02b287822d93c659fc211d1a00bd38eb2e5fd29925543fa4245e0f0b1ba8ee88 with class 0x13d231db173745c3e2d910a8537906d4163617f2dbf0fb005df3c8a460c00476
+[13:29:44.874] INFO: pxe:service Registered account 0x2974756c17646ca139f79b5710b6aee11e2621ce65c882ffd593cfde58d94072
+[13:29:44.913] INFO: pxe:service Simulating transaction execution request to 0x9d57a239 at 0x2974756c17646ca139f79b5710b6aee11e2621ce65c882ffd593cfde58d94072 {"origin":"0x2974756c17646ca139f79b5710b6aee11e2621ce65c882ffd593cfde58d94072","functionSelector":"0x9d57a239","simulatePublic":true,"chainId":"0x0000000000000000000000000000000000000000000000000000000000007a69","version":"0x0000000000000000000000000000000000000000000000000000000032613638","authWitnesses":["0x209ad5ddf34873c4ef369c35944e1d1fc62c0ee24f73a21af93f18041b703a16"]}
+Estimated gas usage:    da=26471,l2=89151,teardownDA=0,teardownL2=0
+Maximum total tx fee:   136401030
+[13:29:45.446] INFO: pxe:service Simulation completed for 0x27789f04c9d42886acd26c84212099984cf8e8ca3702ab328a60c27a6ab54bed in 533.105751ms {"txHash":"0x27789f04c9d42886acd26c84212099984cf8e8ca3702ab328a60c27a6ab54bed","origin":"0x2974756c17646ca139f79b5710b6aee11e2621ce65c882ffd593cfde58d94072","functionSelector":"0x9d57a239","simulatePublic":true,"chainId":"0x0000000000000000000000000000000000000000000000000000000000007a69","version":"0x0000000000000000000000000000000000000000000000000000000032613638","authWitnesses":["0x209ad5ddf34873c4ef369c35944e1d1fc62c0ee24f73a21af93f18041b703a16"],"gasUsed":{"totalGas":{"daGas":24064,"l2Gas":81046},"teardownGas":{"daGas":0,"l2Gas":0},"publicGas":{"daGas":3072,"l2Gas":13089},"billedGas":{"daGas":24064,"l2Gas":81046}},"revertCode":0}
+[13:29:47.872] INFO: pxe:private-kernel-execution-prover Private kernel witness generation took 1500.3789180000003ms
+[13:29:47.872] INFO: pxe:bb:native Generating ClientIVC proof...
+Contract deployed at 0x02b287822d93c659fc211d1a00bd38eb2e5fd29925543fa4245e0f0b1ba8ee88
+Contract partial address 0x1c7431864509046edb361751e87a977c83bb845f949bce8c1cedd818d5808624
+Contract init hash 0x13d93e469cd1a483eec70a6f6e782135b4232b0ef7b2006f4561184857f0aa1c
+Deployment tx hash: 0x1c2f5a6238c84c47686f51e42cb7db4cee847f58ab1e18b65af6a5046491805a
+Deployment salt: 0x25ee605ccff8b1b147a2f3b81fe9e37a02c0e002585eccc0fb2f81555646f803
+Deployer: 0x2974756c17646ca139f79b5710b6aee11e2621ce65c882ffd593cfde58d94072
+[13:29:56.374] INFO: pxe:bb:native Generated ClientIVC proof {"eventName":"client-ivc-proof-generation","duration":8501.806045000001,"proofSize":5003}
+[13:29:56.502] INFO: wallet-sdk:base_wallet Sent transaction 0x1c2f5a6238c84c47686f51e42cb7db4cee847f58ab1e18b65af6a5046491805a
+Transaction fee: 82666920
+Contract stored in database with aliases last & privatebonds
+
+Contract deployed. Issuer holds 1,000,000 bonds privately.
+
+Verifying issuer's private balance:
+[13:30:00.678] INFO: pxe:data:lmdb Creating pxe_data data store at directory /Users/yanismeziane/.aztec/wallet/pxe/pxe_data with map size 134217728 KB (LMDB v2)
+[13:30:00.681] INFO: pxe:data:lmdb Starting data store with maxReaders 16
+Using Fee Juice for fee payment with the balance of account 0x2974756c17646ca139f79b5710b6aee11e2621ce65c882ffd593cfde58d94072
+[13:30:01.036] INFO: pxe:service Started PXE connected to chain 31337 version 845231672
+[13:30:01.036] INFO: kv-store:lmdb-v2 Starting data store with maxReaders 16
+
+Simulation result:  1000000n
+
+
+==============================================================
+PHASE 2: KYC & WHITELISTING
+==============================================================
+
+Investor A and Investor B complete KYC verification off-chain...
+(In production: ID verification, accreditation checks, AML screening)
+
+Issuer adds verified investors to whitelist...
+
+PRIVACY: Whitelist is PUBLIC - everyone can see who is authorized
+         to hold bonds. This is required for regulatory compliance.
+
+Adding Investor A to whitelist...
+[13:30:02.669] INFO: pxe:data:lmdb Creating pxe_data data store at directory /Users/yanismeziane/.aztec/wallet/pxe/pxe_data with map size 134217728 KB (LMDB v2)
+[13:30:02.673] INFO: pxe:data:lmdb Starting data store with maxReaders 16
+Using Fee Juice for fee payment with the balance of account 0x2974756c17646ca139f79b5710b6aee11e2621ce65c882ffd593cfde58d94072
+[13:30:03.028] INFO: pxe:service Started PXE connected to chain 31337 version 845231672
+[13:30:03.028] INFO: kv-store:lmdb-v2 Starting data store with maxReaders 16
+[13:30:03.043] INFO: wallet Using wallet with address 0x2974756c17646ca139f79b5710b6aee11e2621ce65c882ffd593cfde58d94072
+[13:30:03.172] INFO: pxe:service Registered account 0x2974756c17646ca139f79b5710b6aee11e2621ce65c882ffd593cfde58d94072
+[13:30:03.213] INFO: pxe:service Simulating transaction execution request to 0x9d57a239 at 0x2974756c17646ca139f79b5710b6aee11e2621ce65c882ffd593cfde58d94072 {"origin":"0x2974756c17646ca139f79b5710b6aee11e2621ce65c882ffd593cfde58d94072","functionSelector":"0x9d57a239","simulatePublic":true,"chainId":"0x0000000000000000000000000000000000000000000000000000000000007a69","version":"0x0000000000000000000000000000000000000000000000000000000032613638","authWitnesses":["0x2a6bb65c49ae227d6add9c19b888d78ce001a9a7eabd306b5aa61425a5060cf4"]}
+Estimated gas usage:    da=2816,l2=46400,teardownDA=0,teardownL2=0
+Maximum total tx fee:   70992000
+[13:30:03.447] INFO: pxe:service Simulation completed for 0x06df2f207a0a43a070fd3b74e0f449b46c8347433165a5fd9770e5ea3350c71a in 233.79512499999987ms {"txHash":"0x06df2f207a0a43a070fd3b74e0f449b46c8347433165a5fd9770e5ea3350c71a","origin":"0x2974756c17646ca139f79b5710b6aee11e2621ce65c882ffd593cfde58d94072","functionSelector":"0x9d57a239","simulatePublic":true,"chainId":"0x0000000000000000000000000000000000000000000000000000000000007a69","version":"0x0000000000000000000000000000000000000000000000000000000032613638","authWitnesses":["0x2a6bb65c49ae227d6add9c19b888d78ce001a9a7eabd306b5aa61425a5060cf4"],"gasUsed":{"totalGas":{"daGas":2560,"l2Gas":42181},"teardownGas":{"daGas":0,"l2Gas":0},"publicGas":{"daGas":1024,"l2Gas":18589},"billedGas":{"daGas":2560,"l2Gas":42181}},"revertCode":0}
+[13:30:04.591] INFO: pxe:private-kernel-execution-prover Private kernel witness generation took 856.9000409999999ms
+[13:30:04.592] INFO: pxe:bb:native Generating ClientIVC proof...
+
+Transaction hash: 0x04e4906f4b8b7c2987e6c81a22a0d362566c61851fc6bbc533d9b5279aedec30
+[13:30:12.061] INFO: pxe:bb:native Generated ClientIVC proof {"eventName":"client-ivc-proof-generation","duration":7469.607877999999,"proofSize":5003}
+[13:30:12.194] INFO: wallet-sdk:base_wallet Sent transaction 0x04e4906f4b8b7c2987e6c81a22a0d362566c61851fc6bbc533d9b5279aedec30
+Transaction has been mined
+ Tx fee: 43024620
+ Status: success
+ Block number: 28
+ Block hash: 0x0f1d0304759f89902aea986dcf7a23ecebb9b98eddde8046625adb132b5aac91
+Transaction hash stored in database with aliases last & add_to_whitelist-cae395681b18d281555552bced9691ce
+
+Adding Investor B to whitelist...
+[13:30:37.725] INFO: pxe:data:lmdb Creating pxe_data data store at directory /Users/yanismeziane/.aztec/wallet/pxe/pxe_data with map size 134217728 KB (LMDB v2)
+[13:30:37.728] INFO: pxe:data:lmdb Starting data store with maxReaders 16
+Using Fee Juice for fee payment with the balance of account 0x2974756c17646ca139f79b5710b6aee11e2621ce65c882ffd593cfde58d94072
+[13:30:38.169] INFO: pxe:service Started PXE connected to chain 31337 version 845231672
+[13:30:38.169] INFO: kv-store:lmdb-v2 Starting data store with maxReaders 16
+[13:30:38.192] INFO: wallet Using wallet with address 0x2974756c17646ca139f79b5710b6aee11e2621ce65c882ffd593cfde58d94072
+[13:30:38.424] INFO: pxe:service Registered account 0x2974756c17646ca139f79b5710b6aee11e2621ce65c882ffd593cfde58d94072
+[13:30:38.467] INFO: pxe:service Simulating transaction execution request to 0x9d57a239 at 0x2974756c17646ca139f79b5710b6aee11e2621ce65c882ffd593cfde58d94072 {"origin":"0x2974756c17646ca139f79b5710b6aee11e2621ce65c882ffd593cfde58d94072","functionSelector":"0x9d57a239","simulatePublic":true,"chainId":"0x0000000000000000000000000000000000000000000000000000000000007a69","version":"0x0000000000000000000000000000000000000000000000000000000032613638","authWitnesses":["0x2187d41df2610bc420b1b5fa8fe18f0b8abb41a5cc27608cc6862216cb91ae04"]}
+Estimated gas usage:    da=2816,l2=46400,teardownDA=0,teardownL2=0
+Maximum total tx fee:   70992000
+[13:30:38.728] INFO: pxe:service Simulation completed for 0x00ad5e03150d52dc167e6a3efaa9150445f05b5724696f0f0c77378d1a0ad4dc in 260.91170899999975ms {"txHash":"0x00ad5e03150d52dc167e6a3efaa9150445f05b5724696f0f0c77378d1a0ad4dc","origin":"0x2974756c17646ca139f79b5710b6aee11e2621ce65c882ffd593cfde58d94072","functionSelector":"0x9d57a239","simulatePublic":true,"chainId":"0x0000000000000000000000000000000000000000000000000000000000007a69","version":"0x0000000000000000000000000000000000000000000000000000000032613638","authWitnesses":["0x2187d41df2610bc420b1b5fa8fe18f0b8abb41a5cc27608cc6862216cb91ae04"],"gasUsed":{"totalGas":{"daGas":2560,"l2Gas":42181},"teardownGas":{"daGas":0,"l2Gas":0},"publicGas":{"daGas":1024,"l2Gas":18589},"billedGas":{"daGas":2560,"l2Gas":42181}},"revertCode":0}
+[13:30:40.515] INFO: pxe:private-kernel-execution-prover Private kernel witness generation took 1487.5557090000002ms
+[13:30:40.516] INFO: pxe:bb:native Generating ClientIVC proof...
+[13:30:47.738] INFO: pxe:bb:native Generated ClientIVC proof {"eventName":"client-ivc-proof-generation","duration":7221.900462,"proofSize":5003}
+
+Transaction hash: 0x036f9b99c436db31f7fae4620e06c2442aed2896bef891b6de37f91a915c2a97
+[13:30:47.957] INFO: wallet-sdk:base_wallet Sent transaction 0x036f9b99c436db31f7fae4620e06c2442aed2896bef891b6de37f91a915c2a97
+Transaction has been mined
+ Tx fee: 43024620
+ Status: success
+ Block number: 29
+ Block hash: 0x20c98166c5cd3026c13fd5a054aa9dab1899d6da8b02ef81522634f9ee4a0398
+Transaction hash stored in database with aliases last & add_to_whitelist-89709ac846b0a84a97ca1d085cd069be
+
+Both investors are now authorized to hold bonds.
+
+==============================================================
+PHASE 3: PRIMARY MARKET - PRIVATE DISTRIBUTION
+==============================================================
+
+Investors wire fiat to Issuer's bank account (off-chain)...
+
+Issuer distributes bonds PRIVATELY from their pool:
+  - Using distribute_private() - a private transfer from issuer
+  - Total supply remains UNCHANGED (1,000,000)
+  - Individual allocations are PRIVATE
+
+PRIVACY: Observers see whitelist checks but NOT the amounts.
+         Total supply stays at 1M - no leakage!
+
+Investor A purchases bonds (amount HIDDEN)...
+  [Off-chain: Investor A wired payment for their allocation]
+[13:30:52.203] INFO: pxe:data:lmdb Creating pxe_data data store at directory /Users/yanismeziane/.aztec/wallet/pxe/pxe_data with map size 134217728 KB (LMDB v2)
+[13:30:52.212] INFO: pxe:data:lmdb Starting data store with maxReaders 16
+Using Fee Juice for fee payment with the balance of account 0x2974756c17646ca139f79b5710b6aee11e2621ce65c882ffd593cfde58d94072
+[13:30:52.686] INFO: pxe:service Started PXE connected to chain 31337 version 845231672
+[13:30:52.686] INFO: kv-store:lmdb-v2 Starting data store with maxReaders 16
+[13:30:52.701] INFO: wallet Using wallet with address 0x2974756c17646ca139f79b5710b6aee11e2621ce65c882ffd593cfde58d94072
+[13:30:52.857] INFO: pxe:service Registered account 0x2974756c17646ca139f79b5710b6aee11e2621ce65c882ffd593cfde58d94072
+[13:30:52.900] INFO: pxe:service Simulating transaction execution request to 0x9d57a239 at 0x2974756c17646ca139f79b5710b6aee11e2621ce65c882ffd593cfde58d94072 {"origin":"0x2974756c17646ca139f79b5710b6aee11e2621ce65c882ffd593cfde58d94072","functionSelector":"0x9d57a239","simulatePublic":true,"chainId":"0x0000000000000000000000000000000000000000000000000000000000007a69","version":"0x0000000000000000000000000000000000000000000000000000000032613638","authWitnesses":["0x0f099ad0b369f16e72bf7e87be56fc9726ab889879127f7973efb9be28b1ae97"]}
+Estimated gas usage:    da=24781,l2=67333,teardownDA=0,teardownL2=0
+Maximum total tx fee:   103019490
+[13:30:53.730] INFO: pxe:service Simulation completed for 0x1647e2bdf1c8666aa52ffaf3e9f94f56bd331daefca9b8bf8be32f9003b8c8d8 in 829.6987090000002ms {"txHash":"0x1647e2bdf1c8666aa52ffaf3e9f94f56bd331daefca9b8bf8be32f9003b8c8d8","origin":"0x2974756c17646ca139f79b5710b6aee11e2621ce65c882ffd593cfde58d94072","functionSelector":"0x9d57a239","simulatePublic":true,"chainId":"0x0000000000000000000000000000000000000000000000000000000000007a69","version":"0x0000000000000000000000000000000000000000000000000000000032613638","authWitnesses":["0x0f099ad0b369f16e72bf7e87be56fc9726ab889879127f7973efb9be28b1ae97"],"gasUsed":{"totalGas":{"daGas":22528,"l2Gas":61211},"teardownGas":{"daGas":0,"l2Gas":0},"publicGas":{"daGas":0,"l2Gas":13509},"billedGas":{"daGas":22528,"l2Gas":61211}},"revertCode":0}
+[13:30:55.683] INFO: pxe:private-kernel-execution-prover Private kernel witness generation took 1231.3853339999996ms
+[13:30:55.683] INFO: pxe:bb:native Generating ClientIVC proof...
+
+Transaction hash: 0x0add6ec2fddd8988e140758e7c163128355d7f2bcb15a187537dcd84562de58a
+[13:31:04.683] INFO: pxe:bb:native Generated ClientIVC proof {"eventName":"client-ivc-proof-generation","duration":8999.400628,"proofSize":5003}
+[13:31:04.840] INFO: wallet-sdk:base_wallet Sent transaction 0x0add6ec2fddd8988e140758e7c163128355d7f2bcb15a187537dcd84562de58a
+Transaction has been mined
+ Tx fee: 62435220
+ Status: success
+ Block number: 30
+ Block hash: 0x0b957f6ddf87c02782108e567df409e12a1be6052e8d10ec84c82624ac12c225
+Transaction hash stored in database with aliases last & distribute_private-88dd85af3a2f5bab3a609ff905de85b5
+
+Investor B purchases bonds (amount HIDDEN)...
+  [Off-chain: Investor B wired payment for their allocation]
+[13:31:28.828] INFO: pxe:data:lmdb Creating pxe_data data store at directory /Users/yanismeziane/.aztec/wallet/pxe/pxe_data with map size 134217728 KB (LMDB v2)
+[13:31:28.831] INFO: pxe:data:lmdb Starting data store with maxReaders 16
+Using Fee Juice for fee payment with the balance of account 0x2974756c17646ca139f79b5710b6aee11e2621ce65c882ffd593cfde58d94072
+[13:31:29.191] INFO: pxe:service Started PXE connected to chain 31337 version 845231672
+[13:31:29.191] INFO: kv-store:lmdb-v2 Starting data store with maxReaders 16
+[13:31:29.206] INFO: wallet Using wallet with address 0x2974756c17646ca139f79b5710b6aee11e2621ce65c882ffd593cfde58d94072
+[13:31:29.335] INFO: pxe:service Registered account 0x2974756c17646ca139f79b5710b6aee11e2621ce65c882ffd593cfde58d94072
+[13:31:29.376] INFO: pxe:service Simulating transaction execution request to 0x9d57a239 at 0x2974756c17646ca139f79b5710b6aee11e2621ce65c882ffd593cfde58d94072 {"origin":"0x2974756c17646ca139f79b5710b6aee11e2621ce65c882ffd593cfde58d94072","functionSelector":"0x9d57a239","simulatePublic":true,"chainId":"0x0000000000000000000000000000000000000000000000000000000000007a69","version":"0x0000000000000000000000000000000000000000000000000000000032613638","authWitnesses":["0x227916499781f44fc63e7a8e7f075b144efa34f60c7c77e921550743ee0a112e"]}
+Estimated gas usage:    da=24781,l2=67333,teardownDA=0,teardownL2=0
+Maximum total tx fee:   103019490
+[13:31:30.320] INFO: pxe:service Simulation completed for 0x2810f5e658013e67dca97fd8a4286753b5c4cc59f7490aa609afc8fe8dee59c7 in 943.7174999999997ms {"txHash":"0x2810f5e658013e67dca97fd8a4286753b5c4cc59f7490aa609afc8fe8dee59c7","origin":"0x2974756c17646ca139f79b5710b6aee11e2621ce65c882ffd593cfde58d94072","functionSelector":"0x9d57a239","simulatePublic":true,"chainId":"0x0000000000000000000000000000000000000000000000000000000000007a69","version":"0x0000000000000000000000000000000000000000000000000000000032613638","authWitnesses":["0x227916499781f44fc63e7a8e7f075b144efa34f60c7c77e921550743ee0a112e"],"gasUsed":{"totalGas":{"daGas":22528,"l2Gas":61211},"teardownGas":{"daGas":0,"l2Gas":0},"publicGas":{"daGas":0,"l2Gas":13509},"billedGas":{"daGas":22528,"l2Gas":61211}},"revertCode":0}
+[13:31:32.486] INFO: pxe:private-kernel-execution-prover Private kernel witness generation took 1239.598959ms
+[13:31:32.486] INFO: pxe:bb:native Generating ClientIVC proof...
+
+Transaction hash: 0x1dd55bfe012224eb7c187223d3b5c5243f028d2374e939cb1e332ce5c62e1834
+[13:31:41.626] INFO: pxe:bb:native Generated ClientIVC proof {"eventName":"client-ivc-proof-generation","duration":9145.383420000002,"proofSize":5003}
+[13:31:41.790] INFO: wallet-sdk:base_wallet Sent transaction 0x1dd55bfe012224eb7c187223d3b5c5243f028d2374e939cb1e332ce5c62e1834
+Transaction has been mined
+ Tx fee: 62435220
+ Status: success
+ Block number: 31
+ Block hash: 0x07d112151e47e61766cc2408aec907964cda3ae5cb0e85df6a0119daa963f80f
+Transaction hash stored in database with aliases last & distribute_private-4155b97b458cd5f52c63408c00b63f98
+
+Primary distribution complete.
+
+What the PUBLIC can see:
+  - Investor A is a bondholder (whitelisted)
+  - Investor B is a bondholder (whitelisted)
+  - Total supply: 1,000,000 (UNCHANGED!)
+
+What the PUBLIC CANNOT see:
+  - Investor A's allocation: ??? (encrypted)
+  - Investor B's allocation: ??? (encrypted)
+  - Issuer's remaining pool: ??? (encrypted)
+
+Verifying balances (private - only visible to account owner):
+
+Issuer's remaining private balance (should be 200,000):
+[13:32:06.361] INFO: pxe:data:lmdb Creating pxe_data data store at directory /Users/yanismeziane/.aztec/wallet/pxe/pxe_data with map size 134217728 KB (LMDB v2)
+[13:32:06.365] INFO: pxe:data:lmdb Starting data store with maxReaders 16
+Using Fee Juice for fee payment with the balance of account 0x2974756c17646ca139f79b5710b6aee11e2621ce65c882ffd593cfde58d94072
+[13:32:06.723] INFO: pxe:service Started PXE connected to chain 31337 version 845231672
+[13:32:06.723] INFO: kv-store:lmdb-v2 Starting data store with maxReaders 16
+
+Simulation result:  200000n
+
+
+Investor A's private balance (should be 500,000):
+[13:32:08.448] INFO: pxe:data:lmdb Creating pxe_data data store at directory /Users/yanismeziane/.aztec/wallet/pxe/pxe_data with map size 134217728 KB (LMDB v2)
+[13:32:08.450] INFO: pxe:data:lmdb Starting data store with maxReaders 16
+[13:32:08.784] INFO: pxe:service Started PXE connected to chain 31337 version 845231672
+[13:32:08.785] INFO: kv-store:lmdb-v2 Starting data store with maxReaders 16
+Using Fee Juice for fee payment with the balance of account 0x0c28d3544b8c71648627c230b8e10ff7bdafb364957867473dbcf3c4f483b064
+
+Simulation result:  500000n
+
+
+Investor B's private balance (should be 300,000):
+[13:32:10.671] INFO: pxe:data:lmdb Creating pxe_data data store at directory /Users/yanismeziane/.aztec/wallet/pxe/pxe_data with map size 134217728 KB (LMDB v2)
+[13:32:10.673] INFO: pxe:data:lmdb Starting data store with maxReaders 16
+[13:32:11.016] INFO: pxe:service Started PXE connected to chain 31337 version 845231672
+[13:32:11.016] INFO: kv-store:lmdb-v2 Starting data store with maxReaders 16
+Using Fee Juice for fee payment with the balance of account 0x08cad1e03676948f661bc00df74eadac619fc961aa8bf9ee7ca9e9b64291485c
+
+Simulation result:  300000n
+
+
+==============================================================
+PHASE 4: SECONDARY MARKET - PRIVATE TRADING
+==============================================================
+
+Investor A wants to sell 100,000 bonds to Investor B.
+
+Trade agreement (off-chain or via atomic DvP):
+  - Investor A sells: 100,000 bonds
+  - Investor B pays: (price agreed off-chain or via payment token)
+
+Executing private transfer...
+
+PRIVACY: This is the MOST PRIVATE operation:
+  - Sender: HIDDEN
+  - Recipient: Revealed via whitelist check
+  - Amount: HIDDEN
+  - Total supply: UNCHANGED (still 1,000,000)
+
+[13:32:12.883] INFO: pxe:data:lmdb Creating pxe_data data store at directory /Users/yanismeziane/.aztec/wallet/pxe/pxe_data with map size 134217728 KB (LMDB v2)
+[13:32:12.885] INFO: pxe:data:lmdb Starting data store with maxReaders 16
+Using Fee Juice for fee payment with the balance of account 0x0c28d3544b8c71648627c230b8e10ff7bdafb364957867473dbcf3c4f483b064
+[13:32:13.283] INFO: pxe:service Started PXE connected to chain 31337 version 845231672
+[13:32:13.283] INFO: kv-store:lmdb-v2 Starting data store with maxReaders 16
+[13:32:13.297] INFO: wallet Using wallet with address 0x0c28d3544b8c71648627c230b8e10ff7bdafb364957867473dbcf3c4f483b064
+[13:32:13.424] INFO: pxe:service Registered account 0x0c28d3544b8c71648627c230b8e10ff7bdafb364957867473dbcf3c4f483b064
+[13:32:13.465] INFO: pxe:service Simulating transaction execution request to 0x9d57a239 at 0x0c28d3544b8c71648627c230b8e10ff7bdafb364957867473dbcf3c4f483b064 {"origin":"0x0c28d3544b8c71648627c230b8e10ff7bdafb364957867473dbcf3c4f483b064","functionSelector":"0x9d57a239","simulatePublic":true,"chainId":"0x0000000000000000000000000000000000000000000000000000000000007a69","version":"0x0000000000000000000000000000000000000000000000000000000032613638","authWitnesses":["0x29b276d1edb870c1888ae0a69be944b5f63f63b3b078207e581bda1957ef0432"]}
+Estimated gas usage:    da=24781,l2=75038,teardownDA=0,teardownL2=0
+Maximum total tx fee:   114808140
+[13:32:14.480] INFO: pxe:service Simulation completed for 0x2dc376d63cfa2aba5444523799f87ec3356aa28f507445f4cb8e3a7ab025cb08 in 1014.2036670000002ms {"txHash":"0x2dc376d63cfa2aba5444523799f87ec3356aa28f507445f4cb8e3a7ab025cb08","origin":"0x0c28d3544b8c71648627c230b8e10ff7bdafb364957867473dbcf3c4f483b064","functionSelector":"0x9d57a239","simulatePublic":true,"chainId":"0x0000000000000000000000000000000000000000000000000000000000007a69","version":"0x0000000000000000000000000000000000000000000000000000000032613638","authWitnesses":["0x29b276d1edb870c1888ae0a69be944b5f63f63b3b078207e581bda1957ef0432"],"gasUsed":{"totalGas":{"daGas":22528,"l2Gas":68216},"teardownGas":{"daGas":0,"l2Gas":0},"publicGas":{"daGas":0,"l2Gas":20514},"billedGas":{"daGas":22528,"l2Gas":68216}},"revertCode":0}
+[13:32:16.925] INFO: pxe:private-kernel-execution-prover Private kernel witness generation took 1357.2192089999999ms
+[13:32:16.926] INFO: pxe:bb:native Generating ClientIVC proof...
+
+Transaction hash: 0x199f78ed24b2145735f4397bc4dbbc647f9a67475afec81838438c7ac0cce7d9
+[13:32:26.762] INFO: pxe:bb:native Generated ClientIVC proof {"eventName":"client-ivc-proof-generation","duration":9836.315672,"proofSize":5003}
+[13:32:26.895] INFO: wallet-sdk:base_wallet Sent transaction 0x199f78ed24b2145735f4397bc4dbbc647f9a67475afec81838438c7ac0cce7d9
+Transaction has been mined
+ Tx fee: 69580320
+ Status: success
+ Block number: 32
+ Block hash: 0x2558591e2a009e50f059945d3028b5bc2ba354523c7fbc307ea614654f85309f
+Transaction hash stored in database with aliases last & transfer_private-fcfaaf01f90a18c359935aa28fe0d4cf
+
+Trade executed.
+
+What happened on-chain (visible to observers):
+  - Some nullifiers published (old notes consumed)
+  - Some note commitments added (new notes created)
+  - Investor B's address was checked against whitelist
+  - Total supply: STILL 1,000,000 (no change!)
+
+What observers CANNOT determine:
+  - Who sent (could be anyone with notes)
+  - How much was transferred
+  - New balances
+
+Updated balances (private - only visible to owners):
+
+Investor A's private balance (should be 400,000):
+[13:32:43.276] INFO: pxe:data:lmdb Creating pxe_data data store at directory /Users/yanismeziane/.aztec/wallet/pxe/pxe_data with map size 134217728 KB (LMDB v2)
+[13:32:43.280] INFO: pxe:data:lmdb Starting data store with maxReaders 16
+Using Fee Juice for fee payment with the balance of account 0x0c28d3544b8c71648627c230b8e10ff7bdafb364957867473dbcf3c4f483b064
+[13:32:43.649] INFO: pxe:service Started PXE connected to chain 31337 version 845231672
+[13:32:43.649] INFO: kv-store:lmdb-v2 Starting data store with maxReaders 16
+
+Simulation result:  400000n
+
+
+Investor B's private balance (should be 400,000):
+[13:32:45.647] INFO: pxe:data:lmdb Creating pxe_data data store at directory /Users/yanismeziane/.aztec/wallet/pxe/pxe_data with map size 134217728 KB (LMDB v2)
+[13:32:45.650] INFO: pxe:data:lmdb Starting data store with maxReaders 16
+Using Fee Juice for fee payment with the balance of account 0x08cad1e03676948f661bc00df74eadac619fc961aa8bf9ee7ca9e9b64291485c
+[13:32:45.991] INFO: pxe:service Started PXE connected to chain 31337 version 845231672
+[13:32:45.991] INFO: kv-store:lmdb-v2 Starting data store with maxReaders 16
+
+Simulation result:  400000n
+
+
+==============================================================
+PHASE 5: REDEMPTION AT MATURITY
+==============================================================
+
+Bond has reached maturity. Investors request redemption.
+
+AUTHWIT REDEMPTION FLOW:
+  1. Investor creates authwit authorizing: redeem(investor, amount, nonce)
+  2. Issuer calls redeem() - #[authorize_once] verifies authwit
+  3. Bonds burned, stablecoin settlement off-chain (PoC) or via DvP (prod)
+
+Investor A redeems their bonds...
+[13:32:48.056] INFO: pxe:data:lmdb Creating pxe_data data store at directory /Users/yanismeziane/.aztec/wallet/pxe/pxe_data with map size 134217728 KB (LMDB v2)
+[13:32:48.058] INFO: pxe:data:lmdb Starting data store with maxReaders 16
+[13:32:48.410] INFO: pxe:service Started PXE connected to chain 31337 version 845231672
+[13:32:48.410] INFO: kv-store:lmdb-v2 Starting data store with maxReaders 16
+[13:32:48.424] INFO: wallet Using wallet with address 0x0c28d3544b8c71648627c230b8e10ff7bdafb364957867473dbcf3c4f483b064
+Using Fee Juice for fee payment with the balance of account 0x0c28d3544b8c71648627c230b8e10ff7bdafb364957867473dbcf3c4f483b064
+[13:32:48.543] INFO: pxe:service Registered account 0x0c28d3544b8c71648627c230b8e10ff7bdafb364957867473dbcf3c4f483b064
+[13:32:48.582] INFO: pxe:service Simulating transaction execution request to 0x9d57a239 at 0x0c28d3544b8c71648627c230b8e10ff7bdafb364957867473dbcf3c4f483b064 {"origin":"0x0c28d3544b8c71648627c230b8e10ff7bdafb364957867473dbcf3c4f483b064","functionSelector":"0x9d57a239","simulatePublic":true,"chainId":"0x0000000000000000000000000000000000000000000000000000000000007a69","version":"0x0000000000000000000000000000000000000000000000000000000032613638","authWitnesses":["0x0272443135236008ac3fe8a869ba9b6f7611fa21064c1d27d3cff228b655cd11"]}
+Estimated gas usage:    da=2253,l2=64070,teardownDA=0,teardownL2=0
+Maximum total tx fee:   98027100
+[13:32:49.471] INFO: pxe:service Simulation completed for 0x0acfecf83e0841adc38b8accce7440876423ccd4bdb19a1714a5f4c0372423e7 in 889.5357919999999ms {"txHash":"0x0acfecf83e0841adc38b8accce7440876423ccd4bdb19a1714a5f4c0372423e7","origin":"0x0c28d3544b8c71648627c230b8e10ff7bdafb364957867473dbcf3c4f483b064","functionSelector":"0x9d57a239","simulatePublic":true,"chainId":"0x0000000000000000000000000000000000000000000000000000000000007a69","version":"0x0000000000000000000000000000000000000000000000000000000032613638","authWitnesses":["0x0272443135236008ac3fe8a869ba9b6f7611fa21064c1d27d3cff228b655cd11"],"gasUsed":{"totalGas":{"daGas":2048,"l2Gas":58245},"teardownGas":{"daGas":0,"l2Gas":0},"publicGas":{"daGas":0,"l2Gas":13113},"billedGas":{"daGas":2048,"l2Gas":58245}},"revertCode":0}
+[13:32:51.606] INFO: pxe:private-kernel-execution-prover Private kernel witness generation took 1346.8261680000005ms
+[13:32:51.606] INFO: pxe:bb:native Generating ClientIVC proof...
+
+Transaction hash: 0x18d2899b41dcf9451b0f33bc21063021985adbcc93922c1e02f7c79cec3bb4c4
+[13:32:59.874] INFO: pxe:bb:native Generated ClientIVC proof {"eventName":"client-ivc-proof-generation","duration":8268.070962,"proofSize":5003}
+[13:32:59.975] INFO: wallet-sdk:base_wallet Sent transaction 0x18d2899b41dcf9451b0f33bc21063021985adbcc93922c1e02f7c79cec3bb4c4
+Transaction has been mined
+ Tx fee: 59409900
+ Status: success
+ Block number: 33
+ Block hash: 0x170478f47c4393e722d48add51fc5c89e8a2347864f4513f5f0ab8b0f9b400e0
+Transaction hash stored in database with aliases last & redeem-57ad84b4fc698ebcf800dfa954f8bc24
+
+Investor B redeems their bonds...
+[13:33:19.401] INFO: pxe:data:lmdb Creating pxe_data data store at directory /Users/yanismeziane/.aztec/wallet/pxe/pxe_data with map size 134217728 KB (LMDB v2)
+[13:33:19.404] INFO: pxe:data:lmdb Starting data store with maxReaders 16
+Using Fee Juice for fee payment with the balance of account 0x08cad1e03676948f661bc00df74eadac619fc961aa8bf9ee7ca9e9b64291485c
+[13:33:19.781] INFO: pxe:service Started PXE connected to chain 31337 version 845231672
+[13:33:19.781] INFO: kv-store:lmdb-v2 Starting data store with maxReaders 16
+[13:33:19.794] INFO: wallet Using wallet with address 0x08cad1e03676948f661bc00df74eadac619fc961aa8bf9ee7ca9e9b64291485c
+[13:33:19.916] INFO: pxe:service Registered account 0x08cad1e03676948f661bc00df74eadac619fc961aa8bf9ee7ca9e9b64291485c
+[13:33:19.959] INFO: pxe:service Simulating transaction execution request to 0x9d57a239 at 0x08cad1e03676948f661bc00df74eadac619fc961aa8bf9ee7ca9e9b64291485c {"origin":"0x08cad1e03676948f661bc00df74eadac619fc961aa8bf9ee7ca9e9b64291485c","functionSelector":"0x9d57a239","simulatePublic":true,"chainId":"0x0000000000000000000000000000000000000000000000000000000000007a69","version":"0x0000000000000000000000000000000000000000000000000000000032613638","authWitnesses":["0x28a345b00a0446c5cbf2e6203fb261e1302876877cb4850e1bc2d51e9b754629"]}
+Estimated gas usage:    da=2816,l2=65764,teardownDA=0,teardownL2=0
+Maximum total tx fee:   100618920
+[13:33:20.879] INFO: pxe:service Simulation completed for 0x03cc4ba229eb41349dbbe0fa1cc135794de3d195765d05b25d055771574efa3d in 919.6093330000001ms {"txHash":"0x03cc4ba229eb41349dbbe0fa1cc135794de3d195765d05b25d055771574efa3d","origin":"0x08cad1e03676948f661bc00df74eadac619fc961aa8bf9ee7ca9e9b64291485c","functionSelector":"0x9d57a239","simulatePublic":true,"chainId":"0x0000000000000000000000000000000000000000000000000000000000007a69","version":"0x0000000000000000000000000000000000000000000000000000000032613638","authWitnesses":["0x28a345b00a0446c5cbf2e6203fb261e1302876877cb4850e1bc2d51e9b754629"],"gasUsed":{"totalGas":{"daGas":2560,"l2Gas":59785},"teardownGas":{"daGas":0,"l2Gas":0},"publicGas":{"daGas":0,"l2Gas":13113},"billedGas":{"daGas":2560,"l2Gas":59785}},"revertCode":0}
+[13:33:22.957] INFO: pxe:private-kernel-execution-prover Private kernel witness generation took 1326.9415009999998ms
+[13:33:22.957] INFO: pxe:bb:native Generating ClientIVC proof...
+
+Transaction hash: 0x29ef734178640e0edde6fb9401bb4197c1cde2e92bdaa276ba96df86ccb78e49
+[13:33:31.334] INFO: pxe:bb:native Generated ClientIVC proof {"eventName":"client-ivc-proof-generation","duration":8377.163629,"proofSize":5003}
+[13:33:31.444] INFO: wallet-sdk:base_wallet Sent transaction 0x29ef734178640e0edde6fb9401bb4197c1cde2e92bdaa276ba96df86ccb78e49
+Transaction has been mined
+ Tx fee: 60980700
+ Status: success
+ Block number: 34
+ Block hash: 0x05a162bebcc13238f256122c1593c91bbfc8d059eba9789162d31e1ccf1276e8
+Transaction hash stored in database with aliases last & redeem-c253947a0733cc4300bc16e0eecb8151
+
+All bonds redeemed (burned).
+In production: DvP contract would atomically transfer stablecoins.
+
+==============================================================
+FINAL STATE
+==============================================================
+
+Investor A's private balance (should be 0 - all redeemed):
+[13:33:34.196] INFO: pxe:data:lmdb Creating pxe_data data store at directory /Users/yanismeziane/.aztec/wallet/pxe/pxe_data with map size 134217728 KB (LMDB v2)
+[13:33:34.199] INFO: pxe:data:lmdb Starting data store with maxReaders 16
+Using Fee Juice for fee payment with the balance of account 0x0c28d3544b8c71648627c230b8e10ff7bdafb364957867473dbcf3c4f483b064
+[13:33:34.562] INFO: pxe:service Started PXE connected to chain 31337 version 845231672
+[13:33:34.562] INFO: kv-store:lmdb-v2 Starting data store with maxReaders 16
+
+Simulation result:  0n
+
+
+Investor B's private balance (should be 0 - all redeemed):
+[13:33:36.694] INFO: pxe:data:lmdb Creating pxe_data data store at directory /Users/yanismeziane/.aztec/wallet/pxe/pxe_data with map size 134217728 KB (LMDB v2)
+[13:33:36.697] INFO: pxe:data:lmdb Starting data store with maxReaders 16
+[13:33:37.036] INFO: pxe:service Started PXE connected to chain 31337 version 845231672
+[13:33:37.036] INFO: kv-store:lmdb-v2 Starting data store with maxReaders 16
+Using Fee Juice for fee payment with the balance of account 0x08cad1e03676948f661bc00df74eadac619fc961aa8bf9ee7ca9e9b64291485c
+
+Simulation result:  0n
+
+
+Issuer's private balance (should be 200,000 - unsold bonds):
+[13:33:38.883] INFO: pxe:data:lmdb Creating pxe_data data store at directory /Users/yanismeziane/.aztec/wallet/pxe/pxe_data with map size 134217728 KB (LMDB v2)
+[13:33:38.886] INFO: pxe:data:lmdb Starting data store with maxReaders 16
+[13:33:39.225] INFO: pxe:service Started PXE connected to chain 31337 version 845231672
+[13:33:39.226] INFO: kv-store:lmdb-v2 Starting data store with maxReaders 16
+Using Fee Juice for fee payment with the balance of account 0x2974756c17646ca139f79b5710b6aee11e2621ce65c882ffd593cfde58d94072
+
+Simulation result:  200000n
+
+
+Total supply (still 1,000,000 - fixed at initialization):
+[13:33:42.324] INFO: pxe:data:lmdb Creating pxe_data data store at directory /Users/yanismeziane/.aztec/wallet/pxe/pxe_data with map size 134217728 KB (LMDB v2)
+[13:33:42.329] INFO: pxe:data:lmdb Starting data store with maxReaders 16
+Using Fee Juice for fee payment with the balance of account 0x2974756c17646ca139f79b5710b6aee11e2621ce65c882ffd593cfde58d94072
+[13:33:42.733] INFO: pxe:service Started PXE connected to chain 31337 version 845231672
+[13:33:42.734] INFO: kv-store:lmdb-v2 Starting data store with maxReaders 16
+
+Simulation result:  1000000n
+
+
+==============================================================
+DEMO COMPLETE
+==============================================================


### PR DESCRIPTION
## Summary

Adds a comprehensive benchmark comparison of three implementation approaches for the private bond use case:
- Custom UTXO (with Railgun reference data)
- Aztec L2 (client-side proving time)
- Zama FHE (estimated from whitepaper)

Key metrics compared:
- Gas costs (where measurable)
- Computation latency (ZK proving / FHE operations)
- Throughput estimates
- Privacy guarantees
- Trade-offs

## Data Sources

- **Custom UTXO**: Uses Railgun production benchmarks as reference since the PoC implementation is not optimized
- **Privacy L2**: Measured client-side proving times from local sandbox (Aztec execution layer not yet live)
- **FHE**: Estimated computation overhead from Zama whitepaper benchmarks (coprocessor is a black box)

## Test Plan

Review the benchmark methodology and data sources:
- [BENCHMARK.md](pocs/private-bond/BENCHMARK.md)
- [Aztec test logs](pocs/private-bond/privacy-l2/logs/test-logs.txt)