### PR TITLE
fix(tee_swap): compatibility in case of field overflow in xor enc

### DIFF
--- a/pocs/approach-private-trade-settlement/tee_swap/circuits/transfer/src/main.nr
+++ b/pocs/approach-private-trade-settlement/tee_swap/circuits/transfer/src/main.nr
@@ -73,22 +73,27 @@ fn field_to_scalar(f: Field) -> EmbeddedCurveScalar {
     EmbeddedCurveScalar { lo, hi }
 }
 
-/// salt encryption
-fn xor_fields(a: Field, b: Field) -> Field {
-    let a_bytes: [u8; 32] = a.to_be_bytes();
-    let b_bytes: [u8; 32] = b.to_be_bytes();
+/// Right-shift a field's big-endian bytes by 3 bits.
+fn shr3_bytes(f: Field) -> [u8; 32] {
+    let bytes: [u8; 32] = f.to_be_bytes();
+    let mut out: [u8; 32] = [0; 32];
+    out[0] = bytes[0] >> 3;
+    for i in 1..32 {
+        out[i] = (bytes[i] >> 3) | ((bytes[i - 1] & 7) << 5);
+    }
+    out
+}
+
+/// Salt encryption: XOR of right-shifted field elements.
+/// Both operands >> 3 => result < 2^251 < p, always a valid Field.
+fn encrypt_salt(salt: Field, enc_key: Field) -> Field {
+    let a = shr3_bytes(salt);
+    let b = shr3_bytes(enc_key);
     let mut xor_bytes: [u8; 32] = [0; 32];
     for i in 0..32 {
-        xor_bytes[i] = a_bytes[i] ^ b_bytes[i];
+        xor_bytes[i] = a[i] ^ b[i];
     }
-    let result = Field::from_be_bytes::<32>(xor_bytes);
-
-    // reject XOR results >= p
-    let roundtrip: [u8; 32] = result.to_be_bytes();
-    for i in 0..32 {
-        assert(roundtrip[i] == xor_bytes[i]);
-    }
-    result
+    Field::from_be_bytes::<32>(xor_bytes)
 }
 
 /// lock mode assertions
@@ -264,7 +269,7 @@ fn main(
 
         // Salt encryption verification
         let enc_key = hash_2([DOMAIN_SALT_ENC, shared.x]);
-        let computed_enc_salt = xor_fields(out_salt, enc_key);
+        let computed_enc_salt = encrypt_salt(out_salt, enc_key);
         assert(computed_enc_salt == encrypted_salt);
         assert(hash_2([DOMAIN_BIND_ENC, encrypted_salt]) == h_enc);
     }
@@ -426,7 +431,7 @@ fn test_valid_lock() {
 
     // Salt encryption
     let enc_key = hash_2([DOMAIN_SALT_ENC, shared.x]);
-    let encrypted_salt_val = xor_fields(out_salt, enc_key);
+    let encrypted_salt_val = encrypt_salt(out_salt, enc_key);
     let h_enc_val = hash_2([DOMAIN_BIND_ENC, encrypted_salt_val]);
 
     main(
@@ -983,7 +988,7 @@ fn test_lock_wrong_stealth() {
     let h_R_val = hash_2([DOMAIN_BIND_R, big_r.x]);
     let h_meta_val = hash_3([DOMAIN_BIND_META, pk_meta.x, out_salt]);
     let enc_key = hash_2([DOMAIN_SALT_ENC, shared.x]);
-    let encrypted_salt_val = xor_fields(out_salt, enc_key);
+    let encrypted_salt_val = encrypt_salt(out_salt, enc_key);
     let h_enc_val = hash_2([DOMAIN_BIND_ENC, encrypted_salt_val]);
 
     let wrong_pk_stealth: Field = 0xdead;
@@ -1063,7 +1068,7 @@ fn test_lock_wrong_h_swap() {
     let h_R_val = hash_2([DOMAIN_BIND_R, big_r.x]);
     let h_meta_val = hash_3([DOMAIN_BIND_META, pk_meta.x, out_salt]);
     let enc_key = hash_2([DOMAIN_SALT_ENC, shared.x]);
-    let encrypted_salt_val = xor_fields(out_salt, enc_key);
+    let encrypted_salt_val = encrypt_salt(out_salt, enc_key);
     let h_enc_val = hash_2([DOMAIN_BIND_ENC, encrypted_salt_val]);
 
     main(
@@ -1192,7 +1197,7 @@ fn test_lock_timeout_must_match_output() {
     let h_R_val = hash_2([DOMAIN_BIND_R, big_r.x]);
     let h_meta_val = hash_3([DOMAIN_BIND_META, pk_meta.x, out_salt]);
     let enc_key = hash_2([DOMAIN_SALT_ENC, shared.x]);
-    let encrypted_salt_val = xor_fields(out_salt, enc_key);
+    let encrypted_salt_val = encrypt_salt(out_salt, enc_key);
     let h_enc_val = hash_2([DOMAIN_BIND_ENC, encrypted_salt_val]);
 
     // Pass wrong timeout (2000 instead of 1000)
@@ -1381,7 +1386,7 @@ fn test_lock_relock_prevention() {
     let h_R_val = hash_2([DOMAIN_BIND_R, big_r.x]);
     let h_meta_val = hash_3([DOMAIN_BIND_META, pk_meta.x, out_salt]);
     let enc_key = hash_2([DOMAIN_SALT_ENC, shared.x]);
-    let encrypted_salt_val = xor_fields(out_salt, enc_key);
+    let encrypted_salt_val = encrypt_salt(out_salt, enc_key);
     let h_enc_val = hash_2([DOMAIN_BIND_ENC, encrypted_salt_val]);
 
     main(
@@ -1462,7 +1467,7 @@ fn test_lock_out_owner_must_equal_stealth() {
     let h_R_val = hash_2([DOMAIN_BIND_R, big_r.x]);
     let h_meta_val = hash_3([DOMAIN_BIND_META, pk_meta.x, out_salt]);
     let enc_key = hash_2([DOMAIN_SALT_ENC, shared.x]);
-    let encrypted_salt_val = xor_fields(out_salt, enc_key);
+    let encrypted_salt_val = encrypt_salt(out_salt, enc_key);
     let h_enc_val = hash_2([DOMAIN_BIND_ENC, encrypted_salt_val]);
 
     main(
@@ -1540,7 +1545,7 @@ fn test_lock_wrong_h_R() {
     let wrong_h_R = hash_2([DOMAIN_BIND_R, 0xdead]);
     let h_meta_val = hash_3([DOMAIN_BIND_META, pk_meta.x, out_salt]);
     let enc_key = hash_2([DOMAIN_SALT_ENC, shared.x]);
-    let encrypted_salt_val = xor_fields(out_salt, enc_key);
+    let encrypted_salt_val = encrypt_salt(out_salt, enc_key);
     let h_enc_val = hash_2([DOMAIN_BIND_ENC, encrypted_salt_val]);
 
     main(
@@ -1619,7 +1624,7 @@ fn test_lock_wrong_h_meta() {
     let h_R_val = hash_2([DOMAIN_BIND_R, big_r.x]);
     let wrong_h_meta = hash_3([DOMAIN_BIND_META, 0xdead, out_salt]);
     let enc_key = hash_2([DOMAIN_SALT_ENC, shared.x]);
-    let encrypted_salt_val = xor_fields(out_salt, enc_key);
+    let encrypted_salt_val = encrypt_salt(out_salt, enc_key);
     let h_enc_val = hash_2([DOMAIN_BIND_ENC, encrypted_salt_val]);
 
     main(
@@ -1698,7 +1703,7 @@ fn test_lock_wrong_h_enc() {
     let h_R_val = hash_2([DOMAIN_BIND_R, big_r.x]);
     let h_meta_val = hash_3([DOMAIN_BIND_META, pk_meta.x, out_salt]);
     let enc_key = hash_2([DOMAIN_SALT_ENC, shared.x]);
-    let encrypted_salt_val = xor_fields(out_salt, enc_key);
+    let encrypted_salt_val = encrypt_salt(out_salt, enc_key);
     let wrong_h_enc = hash_2([DOMAIN_BIND_ENC, 0xdead]);
 
     main(
@@ -1777,7 +1782,7 @@ fn test_lock_wrong_encrypted_salt() {
     let h_R_val = hash_2([DOMAIN_BIND_R, big_r.x]);
     let h_meta_val = hash_3([DOMAIN_BIND_META, pk_meta.x, out_salt]);
     let enc_key = hash_2([DOMAIN_SALT_ENC, shared.x]);
-    let encrypted_salt_val = xor_fields(out_salt, enc_key);
+    let encrypted_salt_val = encrypt_salt(out_salt, enc_key);
     let h_enc_val = hash_2([DOMAIN_BIND_ENC, encrypted_salt_val]);
 
     // Pass wrong encrypted_salt private input

--- a/pocs/approach-private-trade-settlement/tee_swap/src/lib/crypto/salt.rs
+++ b/pocs/approach-private-trade-settlement/tee_swap/src/lib/crypto/salt.rs
@@ -2,8 +2,30 @@ use alloy_primitives::B256;
 
 use super::poseidon::{poseidon2, DOMAIN_SALT_ENC};
 
-/// XOR two B256 values byte-by-byte.
-pub fn xor_b256(a: B256, b: B256) -> B256 {
+/// Right-shift a B256 by 3 bits
+fn shr3(v: B256) -> B256 {
+    let bytes = v.as_slice();
+    let mut out = [0u8; 32];
+    out[0] = bytes[0] >> 3;
+    for i in 1..32 {
+        out[i] = (bytes[i] >> 3) | ((bytes[i - 1] & 7) << 5);
+    }
+    B256::from(out)
+}
+
+/// Left-shift a B256 by 3 bits
+fn shl3(v: B256) -> B256 {
+    let bytes = v.as_slice();
+    let mut out = [0u8; 32];
+    out[31] = bytes[31] << 3;
+    for i in (0..31).rev() {
+        out[i] = (bytes[i] << 3) | (bytes[i + 1] >> 5);
+    }
+    B256::from(out)
+}
+
+/// XOR two B256 values byte-by-byte
+fn xor_b256(a: B256, b: B256) -> B256 {
     let a_bytes = a.as_slice();
     let b_bytes = b.as_slice();
     let mut result = [0u8; 32];
@@ -13,31 +35,39 @@ pub fn xor_b256(a: B256, b: B256) -> B256 {
     B256::from(result)
 }
 
-/// Encrypt a salt using XOR with an ECDH-derived key.
-///
-/// ```text
-/// encryption_key = H(DOMAIN_SALT_ENC, shared_secret.x)
-/// encrypted_salt = salt XOR encryption_key
-/// ```
+/// Encrypt a salt: `shr3(salt) XOR shr3(enc_key)`.
+/// Salt must have bottom 3 bits = 0 for lossless decryption.
 pub fn encrypt_salt(salt: B256, shared_secret_x: B256) -> B256 {
     let enc_key = poseidon2(DOMAIN_SALT_ENC, shared_secret_x);
-    xor_b256(salt, enc_key)
+    xor_b256(shr3(salt), shr3(enc_key))
 }
 
-/// Decrypt a salt using XOR with an ECDH-derived key.
-/// XOR is self-inverse, so decryption is identical to encryption.
+/// Decrypt a salt: `shl3(encrypted XOR shr3(enc_key))`.
 pub fn decrypt_salt(encrypted_salt: B256, shared_secret_x: B256) -> B256 {
-    encrypt_salt(encrypted_salt, shared_secret_x)
+    let enc_key = poseidon2(DOMAIN_SALT_ENC, shared_secret_x);
+    shl3(xor_b256(encrypted_salt, shr3(enc_key)))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
+    /// Produce a canonical field element with bottom 3 bits cleared.
+    fn aligned_salt(seed: u8) -> B256 {
+        let h = poseidon2(B256::left_padding_from(&[seed]), B256::ZERO);
+        let mut bytes: [u8; 32] = h.0;
+        bytes[31] &= 0xF8; // clear bottom 3 bits
+        B256::from(bytes)
+    }
+
+    fn canonical_field(seed: u8) -> B256 {
+        poseidon2(B256::left_padding_from(&[seed]), B256::ZERO)
+    }
+
     #[test]
     fn test_encrypt_decrypt_roundtrip() {
-        let salt = B256::repeat_byte(0x42);
-        let shared_x = B256::repeat_byte(0xAB);
+        let salt = aligned_salt(1);
+        let shared_x = canonical_field(2);
 
         let encrypted = encrypt_salt(salt, shared_x);
         let decrypted = decrypt_salt(encrypted, shared_x);
@@ -47,8 +77,8 @@ mod tests {
 
     #[test]
     fn test_encryption_changes_value() {
-        let salt = B256::repeat_byte(0x42);
-        let shared_x = B256::repeat_byte(0xAB);
+        let salt = aligned_salt(1);
+        let shared_x = canonical_field(2);
 
         let encrypted = encrypt_salt(salt, shared_x);
         assert_ne!(salt, encrypted);
@@ -56,9 +86,9 @@ mod tests {
 
     #[test]
     fn test_different_keys_produce_different_ciphertexts() {
-        let salt = B256::repeat_byte(0x42);
-        let shared_x1 = B256::repeat_byte(0xAB);
-        let shared_x2 = B256::repeat_byte(0xCD);
+        let salt = aligned_salt(1);
+        let shared_x1 = canonical_field(2);
+        let shared_x2 = canonical_field(3);
 
         let enc1 = encrypt_salt(salt, shared_x1);
         let enc2 = encrypt_salt(salt, shared_x2);
@@ -67,19 +97,25 @@ mod tests {
     }
 
     #[test]
-    fn test_xor_self_inverse() {
-        let a = B256::repeat_byte(0xFF);
-        let b = B256::repeat_byte(0x55);
+    fn test_shr3_shl3_roundtrip_aligned() {
+        let v = aligned_salt(42);
+        assert_eq!(shl3(shr3(v)), v);
+    }
 
+    #[test]
+    fn test_xor_self_inverse() {
+        let a = shr3(canonical_field(1));
+        let b = shr3(canonical_field(2));
         let xored = xor_b256(a, b);
         let back = xor_b256(xored, b);
-
         assert_eq!(a, back);
     }
 
     #[test]
-    fn test_xor_with_zero() {
-        let a = B256::repeat_byte(0x42);
-        assert_eq!(xor_b256(a, B256::ZERO), a);
+    fn test_encrypt_with_zero_shared_secret() {
+        let salt = aligned_salt(1);
+        let encrypted = encrypt_salt(salt, B256::ZERO);
+        let decrypted = decrypt_salt(encrypted, B256::ZERO);
+        assert_eq!(salt, decrypted);
     }
 }


### PR DESCRIPTION
This pull request updates the salt encryption logic for private trade settlement, ensuring both safety and invertibility by introducing bit-shifted XOR-based encryption. The main changes replace the previous direct XOR approach with a new scheme that right-shifts field elements before XOR, and left-shifts after decryption, making the process lossless and always producing valid field elements. The implementation is updated in both the circuit and host code, and tests are improved to reflect the new logic.

**Salt Encryption Algorithm Improvements**
- Replaced the previous `xor_fields` function with a new `encrypt_salt` function that right-shifts the field bytes by 3 bits before XOR, ensuring the result is always a valid field element and making decryption lossless. Added corresponding `shr3_bytes` helper. (`pocs/approach-private-trade-settlement/tee_swap/circuits/transfer/src/main.nr`)
- Updated all usages of salt encryption in the main circuit logic and tests to use the new `encrypt_salt` function. (`pocs/approach-private-trade-settlement/tee_swap/circuits/transfer/src/main.nr`) [[1]](diffhunk://#diff-c7e3871e3a04a0354fa21900546832587cabf5aee226cc3c83d9d1c6c74be0ecL267-R272) [[2]](diffhunk://#diff-c7e3871e3a04a0354fa21900546832587cabf5aee226cc3c83d9d1c6c74be0ecL429-R434) [[3]](diffhunk://#diff-c7e3871e3a04a0354fa21900546832587cabf5aee226cc3c83d9d1c6c74be0ecL986-R991) [[4]](diffhunk://#diff-c7e3871e3a04a0354fa21900546832587cabf5aee226cc3c83d9d1c6c74be0ecL1066-R1071) [[5]](diffhunk://#diff-c7e3871e3a04a0354fa21900546832587cabf5aee226cc3c83d9d1c6c74be0ecL1195-R1200) [[6]](diffhunk://#diff-c7e3871e3a04a0354fa21900546832587cabf5aee226cc3c83d9d1c6c74be0ecL1384-R1389) [[7]](diffhunk://#diff-c7e3871e3a04a0354fa21900546832587cabf5aee226cc3c83d9d1c6c74be0ecL1465-R1470) [[8]](diffhunk://#diff-c7e3871e3a04a0354fa21900546832587cabf5aee226cc3c83d9d1c6c74be0ecL1543-R1548) [[9]](diffhunk://#diff-c7e3871e3a04a0354fa21900546832587cabf5aee226cc3c83d9d1c6c74be0ecL1622-R1627) [[10]](diffhunk://#diff-c7e3871e3a04a0354fa21900546832587cabf5aee226cc3c83d9d1c6c74be0ecL1701-R1706) [[11]](diffhunk://#diff-c7e3871e3a04a0354fa21900546832587cabf5aee226cc3c83d9d1c6c74be0ecL1780-R1785)

**Host Encryption/Decryption Logic**
- In the Rust host implementation, added `shr3` and `shl3` functions for right- and left-shifting `B256` values, and updated `encrypt_salt` to use these shifts before XOR. Updated `decrypt_salt` to invert the process, ensuring lossless roundtrip. (`pocs/approach-private-trade-settlement/tee_swap/src/lib/crypto/salt.rs`) [[1]](diffhunk://#diff-bb5b56808aef0a208a138598a01bb3c085dea87ba4756445cb4755962cc77bc6L5-R28) [[2]](diffhunk://#diff-bb5b56808aef0a208a138598a01bb3c085dea87ba4756445cb4755962cc77bc6L16-R70)

**Testing Enhancements**
- Improved test coverage by adding helpers to generate canonical field elements with the bottom 3 bits cleared, ensuring test values are compatible with the new encryption scheme. Added and updated tests for roundtrip correctness, value changes, and XOR properties. (`pocs/approach-private-trade-settlement/tee_swap/src/lib/crypto/salt.rs`) [[1]](diffhunk://#diff-bb5b56808aef0a208a138598a01bb3c085dea87ba4756445cb4755962cc77bc6L50-R91) [[2]](diffhunk://#diff-bb5b56808aef0a208a138598a01bb3c085dea87ba4756445cb4755962cc77bc6L70-R119)