### PR TITLE
docs(diy-validium): clarify STARK→Groth16 proof pipeline

### DIFF
--- a/pocs/diy-validium/README.md
+++ b/pocs/diy-validium/README.md
@@ -44,7 +44,7 @@ Aztec is the most prominent privacy-native L2, using Noir as its ZK language. Di
 | **ZK Language** | Rust via RISC Zero zkVM (general-purpose, large ecosystem) | Noir (ZK-specific DSL, growing ecosystem) |
 | **Compliance Logic** | Custom Rust functions -- institutions write their own rules | Platform-level privacy; custom compliance requires Noir expertise |
 | **Deployment Target** | Ethereum L1 directly (Solidity verifier contracts) | Aztec L2 (separate network, bridges to Ethereum) |
-| **Gas Cost** | High per-proof (~200K--400K gas for STARK verification on L1) | Amortized across L2 block; users pay L2 fees |
+| **Gas Cost** | High per-proof (~200K--300K gas for Groth16 verification on L1; STARKs are compressed to Groth16 before posting) | Amortized across L2 block; users pay L2 fees |
 | **Bridging** | Native -- ERC20 deposits/withdrawals directly on L1 | Requires L1-L2 bridge with messaging delay |
 | **Privacy Model** | Selective: operator sees everything, users prove to auditors | Default encrypted notes; viewing keys for selective disclosure |
 | **Data Availability** | Operator-held (trust assumption) | L2 DA layer with encrypted note storage |
@@ -111,7 +111,7 @@ cd contracts && forge test --offline
 # Dev mode: uses fake proofs for fast iteration (~seconds)
 RISC0_DEV_MODE=1 cargo run
 
-# Real proving: generates actual STARK proofs (~minutes)
+# Real proving: generates STARK proofs locally (~minutes, not compressed to Groth16)
 cargo run
 ```
 
@@ -169,7 +169,7 @@ diy-validium/
 
 **Primitives:**
 - SHA-256 for commitments and Merkle tree hashing (hardware-accelerated in RISC Zero)
-- RISC Zero STARK-based proof system (no trusted setup)
+- RISC Zero STARK-based proof system (STARKs require no trusted setup; on-chain L1 verification uses Groth16 compression, which relies on RISC Zero's universal trusted setup)
 - Binary Merkle trees (depth 20 in spec, depth 4 in demo for speed)
 
 **What is protected:**

--- a/pocs/diy-validium/SPEC.md
+++ b/pocs/diy-validium/SPEC.md
@@ -46,7 +46,7 @@ Build a Validium-style system where:
 - Full account state lives off-chain (operator database)
 - Merkle roots of state are committed on-chain
 - Zero-knowledge proofs validate state transitions
-- RISC Zero provides the proving system (Rust guest programs, no trusted setup)
+- RISC Zero provides the proving system: a STARK-based zkVM (no trusted setup at the proving layer). For on-chain verification, STARK proofs are compressed to Groth16 (~200K-300K gas), which relies on RISC Zero's universal trusted setup (shared across all programs, not per-circuit). The PoC uses `MockRiscZeroVerifier` for testing; production would use `RiscZeroGroth16Verifier`
 
 | Alternative | Why Not |
 |-------------|---------|
@@ -547,7 +547,7 @@ Compare: Circom requires ~80 lines of manual signal routing and SHA-256 constrai
 - **Hash-based disclosure keys** — Production: threshold decryption or verifiable encryption (Penumbra, Aztec)
 - **Simple key derivation** (`pubkey = SHA256(sk)`) — Production: EC key derivation (ed25519)
 - **In-memory storage** — Production: persistent database
-- **IMAGE_IDs as constructor params** — Contracts accept IMAGE_IDs as immutable constructor parameters. The E2E test passes real IMAGE_IDs (from compiled guest ELFs) and real encoded seals via `risc0-ethereum-contracts`. The deploy script defaults to `bytes32(0)` for local/testnet use. Full on-chain verification requires swapping `MockRiscZeroVerifier` for `RiscZeroGroth16Verifier`, which needs Groth16 proof compression (Bonsai or x86 only — ARM Macs cannot produce Groth16 proofs natively).
+- **IMAGE_IDs and proof pipeline** — Contracts accept IMAGE_IDs as immutable constructor parameters. The E2E test passes real IMAGE_IDs (from compiled guest ELFs) and real encoded seals via `risc0-ethereum-contracts`. The deploy script defaults to `bytes32(0)` for local/testnet use. The full proof pipeline is: RISC Zero zkVM generates a STARK proof off-chain → the STARK is compressed to a Groth16 proof (via Bonsai or local x86 prover — ARM Macs cannot produce Groth16 proofs natively) → the Groth16 proof is what the on-chain verifier checks (~200K-300K gas). Full on-chain verification requires swapping `MockRiscZeroVerifier` for `RiscZeroGroth16Verifier`.
 - **No batching** — One proof per operation; production would batch
 - **Single ERC20** — Production: add `asset_id` to commitment scheme
 - **No access control on contract functions** — Any address can submit a valid proof. Production: restrict `executeTransfer` / `withdraw` to an operator address or multisig to prevent front-running and ordering manipulation.
@@ -576,6 +576,8 @@ Compare: Circom requires ~80 lines of manual signal routing and SHA-256 constrai
 - **Escape Hatch** — Emergency withdrawal mechanism when operator is unresponsive or censoring; users reveal balance on-chain to recover funds
 - **Forced Withdrawal** — User-initiated on-chain withdrawal request with a deadline; operator must process it or the system freezes (anti-censorship)
 - **Freeze** — Irreversible state transition that disables normal operations and enables escape withdrawals; triggered by operator inactivity timeout or an expired forced withdrawal request
+- **STARK** — Scalable Transparent Argument of Knowledge. The proof system used by RISC Zero's zkVM. STARKs require no trusted setup but produce large proofs (~hundreds of KB), making direct on-chain verification prohibitively expensive
+- **Groth16** — A succinct non-interactive proof system that produces compact proofs (~200 bytes) verifiable on-chain in ~200K-300K gas. RISC Zero compresses STARK proofs to Groth16 for L1 verification. Groth16 requires a trusted setup — RISC Zero uses a universal setup (shared across all programs, not per-circuit)
 - **Prividium Pattern** — Privacy by default, transparency by choice
 
 ## References


### PR DESCRIPTION
## Summary

- Fix misleading claims about STARK verification on L1 — proofs are compressed to Groth16 before posting (~200K-300K gas)
- Qualify "no trusted setup" statements — STARKs need no setup, but Groth16 compression relies on RISC Zero's universal trusted setup
- Add STARK and Groth16 terminology entries to SPEC.md
- Expand IMAGE_ID limitation bullet to spell out the full proof pipeline

## Test plan

- [x] Grep confirms no remaining unqualified "no trusted setup" or "STARK verification on L1"
- [x] README and SPEC are consistent on gas costs and pipeline description
- [ ] Docs-only change — no code or test changes needed