### PR TITLE
fix(private_identity): some edge cases

### DIFF
--- a/pocs/private-identity/resilient-private-identity/SPEC.md
+++ b/pocs/private-identity/resilient-private-identity/SPEC.md
@@ -398,11 +398,13 @@ Incremental Merkle tree (depth 20, Poseidon t=3 without domain tag) with a unive
 - `rootIndex: uint256` (current position in circular buffer)
 - `insertedLeaves: mapping(bytes32 => bool)` (leaf uniqueness enforcement)
 - `usedEnrollmentNullifiers: mapping(bytes32 => bool)` (vOPRF sybil gate, shared across all callers)
+- `leafEnrollmentNullifier: mapping(uint256 => uint256)` (leaf to enrollment nullifier, cleared on removal to allow re-enrollment)
 - `authorized: mapping(address => bool)` (managed via governance)
 - `governance: address` (multisig, set at deployment)
 
 **Functions:**
-- `insertLeaf(bytes32 leaf, bytes32 enrollmentNullifier) external onlyAuthorized whenNotPaused`: MUST revert if `insertedLeaves[leaf]` is true. MUST revert if `usedEnrollmentNullifiers[enrollmentNullifier]` is true. MUST revert if `nextIndex >= 2^20`. Appends leaf, sets `insertedLeaves[leaf] = true`, sets `usedEnrollmentNullifiers[enrollmentNullifier] = true`, updates Merkle root via path recomputation, pushes root: `recentRoots[rootIndex % 1000] = newRoot; rootIndex = rootIndex + 1`.
+- `insertLeaf(bytes32 leaf, bytes32 enrollmentNullifier) external onlyAuthorized whenNotPaused`: MUST revert if `insertedLeaves[leaf]` is true. MUST revert if `usedEnrollmentNullifiers[enrollmentNullifier]` is true. MUST revert if `nextIndex >= 2^20`. Appends leaf, sets `insertedLeaves[leaf] = true`, sets `usedEnrollmentNullifiers[enrollmentNullifier] = true`, stores `leafEnrollmentNullifier[leaf] = enrollmentNullifier`, updates Merkle root via path recomputation, pushes root: `recentRoots[rootIndex % 1000] = newRoot; rootIndex = rootIndex + 1`.
+- `removeLeaf(uint256 leaf, uint256[] calldata siblingNodes) external onlyAuthorized whenNotPaused`: Removes the leaf from the Merkle tree. Clears `insertedLeaves[leaf]`, `usedEnrollmentNullifiers[leafEnrollmentNullifier[leaf]]`, and `leafEnrollmentNullifier[leaf]` so the same identity can re-enroll after removal. Updates the root circular buffer.
 - `isRecentRoot(bytes32 root) view returns (bool)`: Returns true if root is in `recentRoots`. MUST return false for `bytes32(0)`.
 - `addAuthorized(address addr) external onlyGovernance`: Sets `authorized[addr] = true`.
 - `removeAuthorized(address addr) external onlyGovernance`: Sets `authorized[addr] = false`.
@@ -427,7 +429,7 @@ Handles all enrollment via vOPRF. The vOPRF enrollment nullifier is the universa
 **Governance:** 4-of-7 multisig with 48-hour timelock on MPC key rotation. A separate `guardian` address can veto pending key rotations during the timelock window. The multisig and guardian addresses are set at deployment and are not upgradeable.
 
 **Functions:**
-- `enroll(bytes32 leaf, bytes32 enrollmentNullifier, uint256 G_id_x, uint256 G_id_y, bytes calldata enrollmentProof) external payable whenNotPaused`: Requires `msg.value >= stakeAmount` (default 0.1 ETH). Stake is recorded per leaf and can be reclaimed via `unstake(leaf, siblingNodes)`, which removes the leaf from the identity tree. Reads `mpcPublicKey` from contract storage. Constructs the public input vector `[leaf, enrollmentNullifier, mpcPublicKey.x, mpcPublicKey.y, G_id_x, G_id_y]` and verifies the Noir enrollment proof against the enrollment circuit's verification key. If verification fails AND `block.number <= keyGraceExpiry`, retries with `previousMPCKey`. MUST revert if all verifications fail. Calls `IdentityTree.insertLeaf(leaf, enrollmentNullifier)`.
+- `enroll(bytes32 leaf, bytes32 enrollmentNullifier, uint256 G_id_x, uint256 G_id_y, bytes calldata enrollmentProof) external payable whenNotPaused`: Requires `msg.value == stakeAmount` (default 0.1 ETH). Stake is recorded per leaf and can be reclaimed via `unstake(leaf, siblingNodes)`, which removes the leaf from the identity tree. Reads `mpcPublicKey` from contract storage. Constructs the public input vector `[leaf, enrollmentNullifier, mpcPublicKey.x, mpcPublicKey.y, G_id_x, G_id_y]` and verifies the Noir enrollment proof against the enrollment circuit's verification key. If verification fails AND `block.number <= keyGraceExpiry`, retries with `previousMPCKey`. MUST revert if all verifications fail. Calls `IdentityTree.insertLeaf(leaf, enrollmentNullifier)`.
 - `proposeMPCPublicKey(uint256 x, uint256 y) external onlyMultisig`: MUST verify the point is on BN254 G1: `y^2 == x^3 + 3 mod p`. MUST verify the point is not (0, 0). Sets `pendingKey = (x, y)` and `pendingKeyActivation = block.number + TIMELOCK_BLOCKS`.
 - `finalizeMPCPublicKey() external onlyMultisig`: MUST revert if `block.number < pendingKeyActivation` or `pendingKey == (0, 0)`. Sets `previousMPCKey = mpcPublicKey`, `mpcPublicKey = pendingKey`, `keyGraceExpiry = block.number + GRACE_BLOCKS`, clears `pendingKey`.
 - `vetoPendingKey() external onlyGuardian`: Clears `pendingKey` and `pendingKeyActivation`. Callable only while a proposal is pending.
@@ -447,14 +449,15 @@ Verifies membership and selective disclosure proofs.
 
 **State:**
 - `usedNullifiers: mapping(bytes32 => bool)`
+- `governance: address` (multisig, set at deployment)
 
 **Functions:**
-- `verifyProof(bytes calldata proof, bytes32 root, bytes32 nullifier, bytes32 externalNullifier, uint256 version, uint256 predicateType, uint256 predicateAttrIndex, uint256 predicateValue, uint256 predicateResult) external whenNotPaused`: Constructs the public input vector `[root, nullifier, externalNullifier, version, predicateType, predicateAttrIndex, predicateValue, predicateResult]` and verifies the Noir proof against the membership circuit's verification key. MUST revert if `!IdentityTree.isRecentRoot(root)`. MUST revert if `usedNullifiers[nullifier]` is true. MUST revert if `predicateAttrIndex >= 2` (only indices 0-1 are queryable for version 1). MUST revert if proof verification fails. On success, sets `usedNullifiers[nullifier] = true`.
+- `verifyProof(bytes calldata proof, bytes32 root, bytes32 nullifier, bytes32 externalNullifier, uint256 version, uint256 predicateType, uint256 predicateAttrIndex, uint256 predicateValue, uint256 predicateResult) external whenNotPaused`: NOTE: `externalNullifier` is not validated on-chain. The calling verifier (dApp contract) MUST compute `externalNullifier = H(DOMAIN_EXTERNAL_NULLIFIER, chain_id, verifier_address, scope)` and reject mismatches before calling this function. Constructs the public input vector `[root, nullifier, externalNullifier, version, predicateType, predicateAttrIndex, predicateValue, predicateResult]` and verifies the Noir proof against the membership circuit's verification key. MUST revert if `!IdentityTree.isRecentRoot(root)`. MUST revert if `usedNullifiers[nullifier]` is true. MUST revert if `predicateAttrIndex >= 2` (only indices 0-1 are queryable for version 1). MUST revert if proof verification fails. On success, sets `usedNullifiers[nullifier] = true`.
 
 This function MUST revert on ANY failure condition. It does not return a value. The only observable outcome of a non-reverting call is that the nullifier has been consumed and the proof is valid.
 
 **Events:**
-- `ProofVerified(bytes32 indexed nullifier, bytes32 root, bytes32 externalNullifier, uint256 version)`
+- `ProofVerified(bytes32 indexed nullifier, bytes32 root, bytes32 externalNullifier, uint256 version, uint256 predicateType, uint256 predicateAttrIndex, uint256 predicateValue, uint256 predicateResult)`
 
 ## Cryptographic Details
 

--- a/pocs/private-identity/resilient-private-identity/contracts/script/Deploy.s.sol
+++ b/pocs/private-identity/resilient-private-identity/contracts/script/Deploy.s.sol
@@ -66,7 +66,8 @@ contract Deploy is Script, Config {
         // 4. Deploy IdentityVerifier
         IdentityVerifier identityVerifierContract = new IdentityVerifier(
             address(identityTree),
-            membershipVerifierAddr
+            membershipVerifierAddr,
+            governance
         );
         console.log("IdentityVerifier:", address(identityVerifierContract));
 

--- a/pocs/private-identity/resilient-private-identity/contracts/src/Enrollment.sol
+++ b/pocs/private-identity/resilient-private-identity/contracts/src/Enrollment.sol
@@ -50,9 +50,12 @@ contract Enrollment {
     error NoPendingKey();
     error TimelockNotExpired();
     error KeyAlreadyPending();
-    error InsufficientStake();
+    error StakeAmountMismatch();
     error NotStaker();
     error TransferFailed();
+    error ContractPaused();
+
+    bool public paused;
 
     modifier onlyMultisig() {
         if (msg.sender != multisig) revert NotMultisig();
@@ -61,6 +64,11 @@ contract Enrollment {
 
     modifier onlyGuardian() {
         if (msg.sender != guardian) revert NotGuardian();
+        _;
+    }
+
+    modifier whenNotPaused() {
+        if (paused) revert ContractPaused();
         _;
     }
 
@@ -87,8 +95,8 @@ contract Enrollment {
         uint256 gIdX,
         uint256 gIdY,
         bytes calldata proof
-    ) external payable {
-        if (msg.value < stakeAmount) revert InsufficientStake();
+    ) external payable whenNotPaused {
+        if (msg.value != stakeAmount) revert StakeAmountMismatch();
         bytes32[] memory publicInputs = new bytes32[](6);
         publicInputs[0] = bytes32(leaf);
         publicInputs[1] = bytes32(enrollmentNullifier);
@@ -113,7 +121,7 @@ contract Enrollment {
         emit Enrolled(leaf, enrollmentNullifier);
     }
 
-    function unstake(uint256 leaf, uint256[] calldata siblingNodes) external {
+    function unstake(uint256 leaf, uint256[] calldata siblingNodes) external whenNotPaused {
         if (stakers[leaf] != msg.sender) revert NotStaker();
 
         delete stakers[leaf];
@@ -156,6 +164,14 @@ contract Enrollment {
         pendingKeyActivation = 0;
 
         emit PendingKeyVetoed();
+    }
+
+    function pause() external onlyMultisig {
+        paused = true;
+    }
+
+    function unpause() external onlyMultisig {
+        paused = false;
     }
 
     function _requireOnCurve(uint256 x, uint256 y) internal pure {

--- a/pocs/private-identity/resilient-private-identity/contracts/src/IdentityTree.sol
+++ b/pocs/private-identity/resilient-private-identity/contracts/src/IdentityTree.sol
@@ -13,6 +13,7 @@ contract IdentityTree {
 
     mapping(uint256 => bool) public insertedLeaves;
     mapping(uint256 => bool) public usedEnrollmentNullifiers;
+    mapping(uint256 => uint256) public leafEnrollmentNullifier;
     mapping(address => bool) public authorized;
 
     address public governance;
@@ -52,6 +53,7 @@ contract IdentityTree {
 
         insertedLeaves[leaf] = true;
         usedEnrollmentNullifiers[enrollmentNullifier] = true;
+        leafEnrollmentNullifier[leaf] = enrollmentNullifier;
 
         uint256 index = tree.size;
         tree.insert(leaf);
@@ -65,6 +67,12 @@ contract IdentityTree {
 
     function removeLeaf(uint256 leaf, uint256[] calldata siblingNodes) external onlyAuthorized whenNotPaused {
         tree.remove(leaf, siblingNodes);
+
+        delete insertedLeaves[leaf];
+        uint256 enrollmentNullifier = leafEnrollmentNullifier[leaf];
+        delete usedEnrollmentNullifiers[enrollmentNullifier];
+        delete leafEnrollmentNullifier[leaf];
+
         uint256 newRoot = tree.root();
 
         rootIndex = (rootIndex + 1) % 1000;

--- a/pocs/private-identity/resilient-private-identity/contracts/src/IdentityVerifier.sol
+++ b/pocs/private-identity/resilient-private-identity/contracts/src/IdentityVerifier.sol
@@ -12,21 +12,49 @@ interface IVerifier {
 contract IdentityVerifier {
     IIdentityTree public identityTree;
     IVerifier public verifier;
+    address public governance;
+    bool public paused;
 
     mapping(uint256 => bool) public usedNullifiers;
 
-    event ProofVerified(uint256 indexed nullifier, uint256 root, uint256 externalNullifier, uint256 version);
+    event ProofVerified(
+        uint256 indexed nullifier,
+        uint256 root,
+        uint256 externalNullifier,
+        uint256 version,
+        uint256 predicateType,
+        uint256 predicateAttrIndex,
+        uint256 predicateValue,
+        uint256 predicateResult
+    );
 
     error StaleRoot();
     error NullifierUsed();
     error InvalidAttrIndex();
     error InvalidProof();
+    error NotGovernance();
+    error ContractPaused();
 
-    constructor(address _identityTree, address _verifier) {
-        identityTree = IIdentityTree(_identityTree);
-        verifier = IVerifier(_verifier);
+    modifier onlyGovernance() {
+        if (msg.sender != governance) revert NotGovernance();
+        _;
     }
 
+    modifier whenNotPaused() {
+        if (paused) revert ContractPaused();
+        _;
+    }
+
+    constructor(address _identityTree, address _verifier, address _governance) {
+        identityTree = IIdentityTree(_identityTree);
+        verifier = IVerifier(_verifier);
+        governance = _governance;
+    }
+
+    /// @notice Verify a membership proof with selective disclosure.
+    /// @dev externalNullifier is NOT validated on-chain. The calling verifier (dApp contract)
+    ///      MUST compute externalNullifier = H(DOMAIN, chain_id, verifier_address, scope) and
+    ///      reject mismatches before calling this function. See SPEC section 6.2, step 1 and 4.
     function verifyProof(
         bytes calldata proof,
         uint256 root,
@@ -37,7 +65,7 @@ contract IdentityVerifier {
         uint256 predicateAttrIndex,
         uint256 predicateValue,
         uint256 predicateResult
-    ) external {
+    ) external whenNotPaused {
         if (!identityTree.isRecentRoot(root)) revert StaleRoot();
         if (usedNullifiers[nullifier]) revert NullifierUsed();
         if (predicateAttrIndex >= 2) revert InvalidAttrIndex();
@@ -56,6 +84,14 @@ contract IdentityVerifier {
 
         usedNullifiers[nullifier] = true;
 
-        emit ProofVerified(nullifier, root, externalNullifier, version);
+        emit ProofVerified(nullifier, root, externalNullifier, version, predicateType, predicateAttrIndex, predicateValue, predicateResult);
+    }
+
+    function pause() external onlyGovernance {
+        paused = true;
+    }
+
+    function unpause() external onlyGovernance {
+        paused = false;
     }
 }

--- a/pocs/private-identity/resilient-private-identity/contracts/test/Enrollment.t.sol
+++ b/pocs/private-identity/resilient-private-identity/contracts/test/Enrollment.t.sol
@@ -80,7 +80,7 @@ contract EnrollmentTest is Test {
     }
 
     function test_enroll_revertsOnInsufficientStake() public {
-        vm.expectRevert(Enrollment.InsufficientStake.selector);
+        vm.expectRevert(Enrollment.StakeAmountMismatch.selector);
         enrollment.enroll{value: STAKE_AMOUNT - 1}(42, 100, 5, 6, hex"1234");
     }
 

--- a/pocs/private-identity/resilient-private-identity/contracts/test/IdentityVerifier.t.sol
+++ b/pocs/private-identity/resilient-private-identity/contracts/test/IdentityVerifier.t.sol
@@ -37,6 +37,8 @@ contract IdentityVerifierTest is Test {
     MockVerifier public mockVerifier;
     MockIdentityTree public mockTree;
 
+    address public governanceAddr = address(0xCC);
+
     uint256 constant ROOT = 12345;
     uint256 constant NULLIFIER = 67890;
     uint256 constant EXT_NULLIFIER = 11111;
@@ -45,7 +47,7 @@ contract IdentityVerifierTest is Test {
     function setUp() public {
         mockVerifier = new MockVerifier(true);
         mockTree = new MockIdentityTree();
-        iv = new IdentityVerifier(address(mockTree), address(mockVerifier));
+        iv = new IdentityVerifier(address(mockTree), address(mockVerifier), governanceAddr);
 
         mockTree.setRoot(ROOT, true);
     }
@@ -68,7 +70,7 @@ contract IdentityVerifierTest is Test {
 
     function test_verifyProof_emitsEvent() public {
         vm.expectEmit(true, false, false, true);
-        emit IdentityVerifier.ProofVerified(NULLIFIER, ROOT, EXT_NULLIFIER, VERSION);
+        emit IdentityVerifier.ProofVerified(NULLIFIER, ROOT, EXT_NULLIFIER, VERSION, 1, 0, 100, 1);
 
         iv.verifyProof(hex"1234", ROOT, NULLIFIER, EXT_NULLIFIER, VERSION, 1, 0, 100, 1);
     }


### PR DESCRIPTION
based on 

https://github.com/ethereum/iptf-pocs/pull/56#issuecomment-4244745599

1. fixed
2. this is fine, after 1 is mitigated it doesn't make sense for an attacker to do this
3. fixed
4. not really an issue, root checks would prevent fabrication in this manner. the implementation of `binary_merkle_root` from zk-kit.noir does the root check
5. fixed
6. added a note that says it should be checked out of band
7. fixed