### PR TITLE
docs: sync README PoC table with current state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ Use `[repo]` for repository-wide changes (CI, templates, docs).
 
 ## Unreleased
 
+### [repo]
+- **Changed**: README PoC table synced with current `pocs/` (added `private-identity`, linked published writeups, updated statuses)
+
 ### [diy-validium]
 - **Changed**: IMAGE_IDs from hardcoded `bytes32(0)` constants to immutable constructor params in all contracts
 - **Added**: `risc0-ethereum-contracts` for real seal encoding in E2E test

--- a/README.md
+++ b/README.md
@@ -26,12 +26,13 @@ Each PoC is independent—own language and tooling. No shared dependencies betwe
 
 ## PoCs
 
-| Name | Privacy Primitive | Approaches | Status |
-|------|-------------------|------------|--------|
-| [private-payment](./pocs/private-payment/) | Confidential stablecoin transfers | Shielded Pool (Noir), Plasma (Intmax2) | Complete |
-| [private-bond](./pocs/private-bond/) | Confidential bond transfers | Custom UTXO (Noir), Privacy L2 (Aztec), FHE (Zama) | Complete |
-| [private-trade-settlement](./pocs/private-trade-settlement/) | Confidential atomic DvP | TEE Swap | Complete |
-| [diy-validium](./pocs/diy-validium/) | Confidential institutional payments | Validium (RISC Zero) | Active |
+| Name | Privacy Primitive | Approaches | Status | Writeup |
+|------|-------------------|------------|--------|---------|
+| [private-payment](./pocs/private-payment/) | Confidential stablecoin transfers | Shielded Pool (Noir), Plasma (Intmax2) | Complete | [Shielded Pool](https://iptf.ethereum.org/2026/02/19/building-private-transfers-on-ethereum/), [Plasma](https://iptf.ethereum.org/2026/02/26/private-stablecoins-with-plasma/) |
+| [private-bond](./pocs/private-bond/) | Confidential bond transfers | Custom UTXO (Noir), Privacy L2 (Aztec), FHE (Zama) | Complete | [Part 1 — Custom UTXO](https://iptf.ethereum.org/2026/01/21/building-private-bonds-on-ethereum/), [Part 2 — Aztec](https://iptf.ethereum.org/2026/02/05/private-bonds-on-privacy-l2s/), [Part 3 — FHE](https://iptf.ethereum.org/2026/02/12/private-bonds-with-fhe/) |
+| [private-trade-settlement](./pocs/private-trade-settlement/) | Confidential atomic DvP | TEE Swap | Complete | [Part 1](https://iptf.ethereum.org/2026/03/05/private-crosschain-atomic-swap-part-1/), [Part 2](https://iptf.ethereum.org/2026/03/18/private-crosschain-atomic-swap-part-2/) |
+| [private-identity](./pocs/private-identity/) | Anonymous credentials | Resilient (vOPRF) | Complete | [Resilient Plural Identity](https://iptf.ethereum.org/2026/04/14/resilient-plural-identity/) |
+| [diy-validium](./pocs/diy-validium/) | Confidential institutional payments | Validium (RISC Zero) | Complete | [DIY Validium](https://iptf.ethereum.org/2026/03/18/diy-validium/) |
 
 ## Contributing
 


### PR DESCRIPTION
## Summary
- Added `private-identity` to the PoC table (was missing despite shipped `resilient-private-identity` approach + published post)
- Added a Writeup column linking each PoC/approach to its post on iptf.ethereum.org
- Updated `private-trade-settlement` and `diy-validium` statuses to Complete to match what shipped

## Test plan
- [ ] Render README on GitHub and confirm the table renders correctly
- [ ] Click each Writeup link and confirm it resolves
- [ ] Confirm each `./pocs/...` path resolves on the branch
