### PR TITLE
feat(resilient_civic_participation): specification

### DIFF
--- a/pocs/civic-participation/resilient-civic-participation/SPEC.md
+++ b/pocs/civic-participation/resilient-civic-participation/SPEC.md
@@ -349,6 +349,7 @@ Adversary capabilities:
 - Compelled key disclosure or device compromise of a signer, yielding `(identity_secret, attr_vector, RI Merkle path, s_curr, t, caterpillar, chain_root)` before or after the ratchet for slot `s_slot`.
 - Cross-petition correlation against any observable, including predicate-match intersections.
 - Sybil enrolment of multiple RI identities.
+- Absence of an honest disputant; published batches may go unchallenged for the duration of the dispute window.
 
 Honest-party assumptions: Poseidon1 sponge security and UltraHonk soundness; EIP-4844 blob commitment binding; L1 censorship-resistant inclusion and finality; permissionless Relayer entry such that Signers can resubmit on Relayer-side censorship; Sybil resistance from RI.
 

--- a/pocs/civic-participation/resilient-civic-participation/SPEC.md
+++ b/pocs/civic-participation/resilient-civic-participation/SPEC.md
@@ -1,1 +1,414 @@
-<STUB>
+---
+title: "Resilient Civic Participation"
+status: Draft
+version: 0.1.0
+authors: ["Aaryamann"]
+created: 2026-05-18
+iptf_use_case: "https://github.com/ethereum/iptf-map/blob/master/use-cases/resilient-civic-participation.md"
+iptf_approach: "https://github.com/ethereum/iptf-map/blob/master/approaches/approach-civic-participation.md"
+---
+
+# Resilient Civic Participation: Protocol Specification
+
+## Problem Statement
+
+Civic petitions need signers to prove a stated eligibility criterion without revealing their identity or other petitions they have signed. The outcome must remain verifiable from a durable record after the hosting platform goes offline. Sybil resistance comes from an external credential layer.
+
+A credentialed petition system, composed with the ResilientIdentity (RI) credential layer, anchors per-petition state in an on-chain Indexed Merkle Tree (IMT) and publishes per-signature data on EIP-4844 blob carriers. After the dispute window closes, one resolution SNARK settles the outcome from chain state alone. Each signer maintains a Forward-Secure Ratchet Tree (FSRT) chain that advances past each signed slot, overwriting prior seed material.
+
+### Constraints
+
+- **Privacy.** Cross-process and within-process unlinkability across the public record. Signer identity stays hidden, and no attribute value beyond the predicate's boolean outcome is exposed.
+- **Regulatory.** Outcome publicly verifiable from durable record. Per-class threshold breakdowns come from the predicate's class-binding clause and the Resolver's class-counted outcome bits.
+- **Operational.** After enrollment, signers generate proofs from local state and public on-chain/RI data, without further RI issuer interaction. Outcome reconstructible from chain state once the dispute window closes.
+- **Trust.** RI provides Sybil resistance. Only signers hold FSRT seed material. The signer's submission path assumes at least one reachable honest relay.
+
+### System Overview
+
+- Organizer registers a petition under an RI root `R` and escrows the bounty.
+- Signer builds a signer SNARK against `R` and sends it to a Relayer.
+- Relayer aggregates signer SNARKs into a batch SNARK, then posts it on-chain alongside the EIP-4844 blob carrying the records.
+- During the dispute window, a Disputant MAY submit KZG openings to repudiate a batch. After the window closes, the Resolver submits the resolution SNARK and the Registry pays the bounty.
+
+## Approach
+
+Rejected alternatives:
+
+| Alternative | Reason rejected |
+|-------------|-----------------|
+| Operator-stored signed lists with KYC | Operator state becomes a compelled-disclosure surface; outcome guarantees are lost when the operator goes offline. |
+| ZK with issuer-online revocation | Outcome verifiability depends on continued issuer cooperation; an adversarial issuer blocks participation. |
+| Static identity commitment under one long-lived secret | Device compromise at `T_audit` reveals every past signing identifier under one static-commitment opening. |
+| Per-signature on-chain transactions | Per-signature gas cost exceeds the budget for petitions at the scale of national or supranational civic instruments. |
+
+## Protocol Design
+
+### Participants and Roles
+
+| Component | Role |
+|-----------|------|
+| Signer | Holds an RI credential and an FSRT chain bound through that credential. Produces a single signer SNARK per petition signed. |
+| Organizer | Registers a petition under an RI root `R` and escrows the resolution bounty. |
+| Relayer | Aggregates signer SNARKs into a batch SNARK and publishes the EIP-4844 blob. |
+| Resolver | Computes and submits the resolution SNARK after the dispute window opens. Claims the escrowed bounty on first valid submission. |
+| Disputant | Submits a point-evaluation dispute against a published batch during the dispute window. |
+| Petition Registry | L1 smart contract holding petition state, IMT roots, batch records, and resolution outputs. |
+| RI Credential Layer | Provides the credential tree `R` over RI identities and their attribute commitments. |
+
+### Lifecycle
+
+| From | To | Trigger |
+|------|----|---------|
+| `Registered` | `SigningOpen` | atomic with registration call |
+| `SigningOpen` | `SigningClosed` | first transaction at block `>= close_at_block` |
+| `SigningClosed` | `Cooldown` | atomic with `SigningClosed` entry |
+| `Cooldown` | `DisputeWindow` | first transaction at block `>= close_at_block + 2h` |
+| `DisputeWindow` | `Resolved` | valid resolution SNARK submission |
+| `DisputeWindow` | `Unresolved` | `markUnresolved(petition_id)` at block `>= close_at_block + 14 days`; replaces `running_root` with the tombstone marker |
+
+The Registry MUST enforce the current `state` at every entry point.
+
+### Flows
+
+#### Signer Enrollment
+
+1. Signer MUST sample `s_0` from a CSPRNG with at least 254 bits of entropy.
+2. Signer MUST derive `(v_i, s_{i+1})` for `i in [0, 2^24)` by inductive sponge expansion.
+3. Signer MUST build a depth-24 Poseidon1 Merkle tree over `{v_i}`; the root is `chain_root`.
+4. Signer MUST compute `attr_hash = Poseidon1(DOMAIN_ATTR, attr_0, ..., attr_{n-1}, chain_root, attr_version)` and submit it with the RI enrollment proof; RI appends a leaf under `attr_hash`.
+5. Signer MUST discard `s_1, ..., s_{2^24 - 1}` and intermediate Merkle nodes, and MUST retain `(s_curr = s_0, t = 0, caterpillar, chain_root, attr_version)` per [Off-Chain Signer State](#off-chain-signer-state).
+
+#### Petition Registration
+
+1. Organizer constructs `(R, predicate_def, salt, class_set, class_thresholds, class_index, close_at_block)` and calls `register(petition_data, B)`.
+2. Registry MUST structurally validate the predicate and class-binding clause, MUST recompute and assert `predicate_hash`, MUST derive `petition_id`, MUST assign `slot = S` then increment `S`, MUST snapshot `alpha_at_registration`, and MUST assert `B >= alpha_at_registration * N_expected * predicate_op_count`.
+3. Registry MUST initialise `running_root`, `identity_tag_set_root`, `leaf_count`, `next_batch_index` and MUST emit `PetitionRegistered`.
+
+The signing window MUST satisfy `close_at_block - registration_block <= 11.5 days * BLOCKS_PER_DAY`. Organizer MUST select an `R` that has been published on RI for at least 30 days.
+
+#### Per-Signature Generation
+
+1. Signer MUST read `(slot, R, predicate_def, salt, class_index)` for petition `X` and MUST advance the chain locally from `t` to `slot(X)`, setting `s_curr <- s_{slot(X)}`.
+2. `(v_slot, _) = Poseidon1Sponge.absorb(DOMAIN_FSRT_PRG, s_slot).squeeze(2)`; `class_tag = attr[class_index]`.
+3. `nullifier = Poseidon1(DOMAIN_NULLIFIER, v_slot, petition_id, class_index, class_tag)`; `identity_tag = Poseidon1(DOMAIN_IDTAG, v_slot, petition_id)`.
+4. Signer MUST build the signer SNARK and MUST submit it with `(nullifier, identity_tag, class_tag)` to a relayer.
+5. After L1 finality of the carrying batch, signer MUST overwrite `s_curr` past `s_slot`, advance the caterpillar frontier, and set `t <- slot + 1`. The signer MUST journal this transition to fsync'd storage before the signing counts as complete.
+
+#### Batch Publication
+
+1. Relayer MUST collect signer SNARKs targeting `(petition_id, R, predicate_hash, class_index, slot)` and extract `(nullifier_i, identity_tag_i, class_tag_i)` per position.
+2. Records MUST be ordered by `leaf_i = Poseidon1(DOMAIN_LEAF, nullifier_i, class_tag_i)` ascending and serialised; `batch_versioned_hash` is computed.
+3. Relayer MUST build the batch SNARK with `prior_leaf_count` and `new_leaf_count = prior_leaf_count + batch_size`, then submit `tx(blob, batch SNARK)`. Relayers MUST retain blob bytes locally until L1 finality.
+4. Registry MUST verify the SNARK, MUST revert on failure or on `batch_size` outside `[1, BATCH_SIZE_MAX]`, MUST assert petition bindings and prior-state equality, MUST update state, and MUST emit `BatchPublished`.
+
+#### Dispute
+
+1. Disputant submits `dispute(petition_id, batch_index, position_i, violation_type, opening_proofs, evidence)`.
+2. Registry MUST validate openings via the `0x0A` precompile against `batch_versioned_hash`, MUST apply the violation predicate, MUST set the BatchRecord state to `Repudiated`, MUST advance `next_batch_index` to `batch_index`, MUST roll back `running_root`, `identity_tag_set_root`, and `leaf_count` to the values held by the immediately preceding active batch (or the initial empty-IMT state if no such predecessor exists), and MUST emit `BatchRepudiated`.
+
+Violation types:
+
+| Type | Name | Opening | Predicate |
+|------|------|---------|-----------|
+| `0x01` | class-tag-out-of-set | record `i` (4 field elements) | `class_tag_i` lies outside `class_set` |
+| `0x02` | intra-batch-duplicate-identity-tag | records `i` and `j != i` | `identity_tag_i == identity_tag_j` |
+| `0x03` | leaf-ordering-violation | records `i` and `i + 1` | `leaf_i >= leaf_{i+1}` under canonical BN254 ordering |
+
+#### Resolution
+
+1. Resolver MUST read `(running_root, leaf_count, R, predicate_hash, class_set, class_thresholds, class_index)` and MUST reconstruct `L = {leaf_1, ..., leaf_{leaf_count}}` from blobs of active batches.
+2. For each `c in class_set`, `count[c] = |{leaf in L : class_tag(leaf) = c}|`; `b_per_class[i] = (count[class_set[i]] >= class_thresholds[i])`; `b = AND_i b_per_class[i]`.
+3. Resolver MUST build and submit the resolution SNARK; Registry MUST validate and emit `PetitionResolved` and `BountyPaid`. First valid submission claims the bounty.
+
+After `close_at_block + 14 days` with no valid resolution, any party MAY call `markUnresolved(petition_id)`. The Registry MUST refund the bounty (less a gas rebate to the caller) to the Organizer, MUST replace `running_root` with the tombstone marker, MUST transition the petition state to `Unresolved`, and MUST emit `PetitionUnresolved`.
+
+### Data Structures
+
+#### Predicate
+
+Predicates are postfix expressions over `attr_vector`, evaluated inside the signer SNARK; the grammar is adapted from OpenAC. Comparators are `==`, `<=`, `>=`; logical ops are `AND`, `OR`, `NOT`.
+
+Per-attribute type tags: `INT64` (unsigned 64-bit comparators), `HASH` (equality-only), `BOOL` (equality-only). Bounds: `1 <= predicate_tuple_count <= 20`, `1 <= predicate_op_count <= 20`; the signer SNARK pads to `L_max = 20` operations for constant-time evaluation.
+
+Every petition's predicate MUST include `attr[class_index] == class_tag` as a top-level AND-clause outside any OR sub-expression. The Registry MUST validate this structurally at registration; the signer SNARK enforces it at proving.
+
+`predicate_hash = Poseidon1(DOMAIN_PRED, canonical_predicate_def, petition_id, salt)`; `salt` is a 32-byte nonce registered with the petition definition.
+
+```
+predicate_def := tuple_count u8
+                 tuple[tuple_count]
+                 op_count u8
+                 op[op_count]
+
+tuple        := claim_index u8                   // in [0, n)
+                operand     bytes32              // big-endian
+                type_tag    u8                   // 0x01=INT64, 0x02=HASH, 0x03=BOOL
+                comparator  u8                   // 0x10===, 0x11=<=, 0x12=>=
+
+op           := op_code u8                       // 0x20=PUSH_TUPLE, 0x21=AND,
+                                                 //   0x22=OR, 0x23=NOT, 0xFF=NOP
+                operand u8                       // for PUSH_TUPLE: tuple index;
+                                                 //   zero otherwise
+```
+
+Serialised length `1 + tuple_count * 35 + 1 + op_count * 2`, capped at 1024 bytes. In the signer SNARK, `canonical_predicate_def` is absorbed as 34 BN254 scalars: 31-byte big-endian segments, final segment zero-padded, a one-byte length marker as the first segment's high byte, each segment reduced modulo the BN254 scalar field order.
+
+#### Petition Record
+
+```
+PetitionRecord:
+    petition_id            bytes32
+    slot                   uint32
+    R                      bytes32
+    predicate_def          bytes
+    predicate_hash         bytes32
+    salt                   bytes32
+    class_set              uint16[]
+    class_thresholds       uint64[]
+    class_index            uint8
+    close_at_block         uint64
+    bounty                 uint256
+    alpha_at_registration  uint64
+    organizer              address
+    running_root           bytes32
+    identity_tag_set_root  bytes32
+    leaf_count             uint64
+    next_batch_index       uint32
+    resolution_proof       bytes
+    b                      bool
+    b_per_class            bool[]
+    state                  PetitionState
+```
+
+`PetitionState in {Registered, SigningOpen, SigningClosed, Cooldown, DisputeWindow, Resolved, Unresolved}`.
+
+#### Batch Record
+
+```
+BatchRecord:
+    petition_id               bytes32
+    batch_index               uint32
+    batch_versioned_hash      bytes32
+    new_running_root          bytes32
+    new_identity_tag_set_root bytes32
+    relayer                   address
+    submitted_at_block        uint64
+    state                     BatchState
+```
+
+`BatchState in {Active, Repudiated}`.
+
+#### Global Registry State
+
+```
+GlobalState:
+    S            uint32     // FSRT slot counter; monotone
+    alpha        uint64     // bounty calibration parameter
+    alpha_min    uint64     // governance lower bound on alpha
+    alpha_max    uint64     // governance upper bound on alpha
+    srs_hash     bytes32    // pinned identifier of the UltraHonk SRS
+    chain_id     uint64
+    n            uint8
+```
+
+Minimum-bounty calibration: `N_expected = 10 * sum(class_thresholds)`; `B_min = alpha * N_expected * predicate_op_count`. The Registry MUST keep `alpha_min <= alpha <= alpha_max`; updates bind petitions registered after the update.
+
+Petition identifier: `petition_id = keccak256(DOMAIN_PETITION, chain_id, registry_address, organizer, S_at_registration, predicate_hash_pre_id, close_at_block)`, where `predicate_hash_pre_id` sets `petition_id = 0`; `predicate_hash` is recomputed and stored once `petition_id` is assigned. The tombstone marker is the BN254 scalar `0x0000...0001`.
+
+#### Blob Payload
+
+Each batch occupies one EIP-4844 blob carrying up to 1000 records, each consuming 4 BLS12-381 field elements:
+
+```
+RecordEntry (96 bytes across 4 BLS12-381 field elements):
+    nullifier_bytes      32
+    identity_tag_bytes   32
+    class_tag_bytes      2        // big-endian uint16
+    record_padding       30       // zero
+```
+
+Each BLS12-381 field element is `0x00` top byte plus 31 content bytes; for `(i, j) in [0, 1000) x [0, 4)`, `field_element_index(i, j) = 4i + j` and `field_element_bytes(i, j) = 0x00 || record_bytes(i)[31j : min(31(j+1), 96)]`, with `j = 3` zero-padded to 31 content bytes.
+
+Cross-field binding: Batch SNARK constraint 8. Blob retention: 4096 epochs (EIP-4844 default) from each batch's publication block.
+
+#### Off-Chain Signer State
+
+A signer MUST maintain the following local state (840B total):
+
+| Field | Size | Role |
+|-------|------|------|
+| `s_curr` | 32B | Ratchet head |
+| `t` | 4B | Next slot index |
+| `caterpillar` | 768B | Right-sibling frontier toward leaf `t` |
+| `chain_root` | 32B | Bound in `attr_hash` |
+| `attr_version` | 4B | Bound in `attr_hash` |
+
+`caterpillar` stores 24 BN254 scalars (32-byte big-endian); empty levels hold the empty-subtree Poseidon1 hash; frontier update is `O(log N)` per chain advance [Szydlo]. `attr_version` starts at `0` and increments on each re-enrollment posting a new `attr_hash` leaf.
+
+#### Events
+
+Events (`petition_id` indexed in every event except `AlphaUpdated`, which has no `petition_id`; `batch_index` indexed in `BatchPublished` and `BatchRepudiated`):
+
+- `PetitionRegistered(petition_id, slot, R, predicate_hash, class_set, class_thresholds, class_index, close_at_block, B)`
+- `BatchPublished(petition_id, batch_index, batch_versioned_hash, new_running_root, new_identity_tag_set_root, new_leaf_count)`
+- `BatchRepudiated(petition_id, batch_index, new_running_root, new_identity_tag_set_root, new_leaf_count)`
+- `PetitionResolved(petition_id, b, b_per_class)`
+- `PetitionUnresolved(petition_id)`
+- `BountyPaid(petition_id, recipient, amount)` and `BountyRefunded(petition_id, recipient, amount)`
+- `AlphaUpdated(old_alpha, new_alpha)`
+
+## Cryptographic Details
+
+### Primitives
+
+| Primitive | Parameters |
+|-----------|------------|
+| Poseidon1 permutation (Grassi et al. 2019) | BN254 Fr; `t = 5`; `R_F = 8`, `R_P = 60`; S-box `x^5`; BN254 width-5 MDS and round constants |
+| Poseidon1 sponge | Rate `r = 4`, capacity `c = 1`; `0x80`-prefixed length-padding to a multiple of `r` scalars |
+| BLS12-381 KZG (EIP-4844) | Trusted setup pinned at deployment; SRS identified by `srs_hash` in `GlobalState` |
+| UltraHonk SNARK (Aztec Barretenberg) | Over BN254 KZG; recursive verification |
+| Indexed Merkle Tree (Aztec) | Poseidon1 hashing; depth 24; sorted-linked-list leaves `(value, next_index, next_value)` |
+| Forward-secure ratchet (Bellare-Yee 2003) | Length-doubling PRG instantiated by the Poseidon1 sponge |
+| Caterpillar Merkle frontier (Szydlo) | Log-space Merkle traversal across depth 24 |
+| Keccak-256 (FIPS 202) | `petition_id` derivation; event topic hashing |
+
+### Domain Separators
+
+For each tag `X` in `{nullifier, identity_tag, leaf, fsrt_prg, predicate, attr_hash, batch_snark, petition_id, resolution_snark}`, `DOMAIN_X = Poseidon1(encode("RCP/" || X || "/v1"), 0, 0, 0)`.
+
+`encode: ASCII string -> BN254 scalar` takes strings of length `<= 31`, left-pads with `0x00` to 31 bytes, interprets big-endian, reduces modulo the BN254 scalar field order. Implementations MUST embed the pinned constants at compile time.
+
+### FSRT Chain
+
+Depth-24 Poseidon1 Merkle tree over `N = 2^24` per-slot values from `(v_i, s_{i+1}) = Poseidon1Sponge.absorb(DOMAIN_FSRT_PRG, s_i).squeeze(2)` for `i in [0, N)`. `chain_root` binds into `attr_hash` at RI enrollment. After each finalised signing at slot `k`, the signer MUST, in order, derive `(_, s_{k+1}) = Poseidon1Sponge.absorb(DOMAIN_FSRT_PRG, s_k).squeeze(2)`, set `s_curr <- s_{k+1}` (overwriting `s_k` in place), call `caterpillar.advance(k)`, and set `t <- k + 1`; the transition MUST be journaled to fsync'd storage before it counts as final. `t` is monotone; the global slot counter `S` is bounded by `N - 1 = 2^24 - 1`.
+
+### Signer SNARK
+
+UltraHonk; zero-knowledge.
+
+**Public inputs (ordered):** `R`, `petition_id`, `predicate_hash`, `class_index`, `class_tag`, `slot`, `nullifier`, `identity_tag`.
+
+**Private inputs:** `identity_secret`, `attr_vector`, `attr_version`, `chain_root`, RI Merkle path to the `attr_hash` leaf in `R`, `s_slot`, Merkle path from `v_slot` to `chain_root`, predicate-evaluation stack trace, `canonical_predicate_def`, `salt`.
+
+**Circuit constraints:**
+
+1. `attr_hash = Poseidon1(DOMAIN_ATTR, attr_0, ..., attr_{n-1}, chain_root, attr_version)` opens the leaf at the provided RI Merkle path to `R`.
+2. `predicate_hash = Poseidon1(DOMAIN_PRED, canonical_predicate_def, petition_id, salt)`.
+3. `attr_vector` satisfies `canonical_predicate_def` under postfix evaluation.
+4. `attr[class_index] == class_tag` holds at the top level outside any OR sub-expression.
+5. `(v_slot, _) = Poseidon1Sponge.absorb(DOMAIN_FSRT_PRG, s_slot).squeeze(2)`.
+6. `v_slot` opens at index `slot` in `chain_root` under the provided Merkle path; `chain_root` equals the value bound through `attr_hash`.
+7. `nullifier = Poseidon1(DOMAIN_NULLIFIER, v_slot, petition_id, class_index, class_tag)`.
+8. `identity_tag = Poseidon1(DOMAIN_IDTAG, v_slot, petition_id)`.
+
+### Batch SNARK
+
+UltraHonk; recursive. `BATCH_SIZE_MAX = 100`.
+
+**Public inputs (ordered):** `petition_id`, `R`, `predicate_hash`, `class_index`, `slot`, `batch_size`, `prior_running_root`, `new_running_root`, `prior_identity_tag_set_root`, `new_identity_tag_set_root`, `prior_leaf_count`, `new_leaf_count`, `batch_versioned_hash`.
+
+**Private inputs:** per position `i in [0, batch_size)`, the signer SNARK proof and tuple `(nullifier_i, identity_tag_i, class_tag_i)`; IMT insertion proofs against `prior_running_root` and `prior_identity_tag_set_root`; cross-field decomposition witnesses per [Blob Payload](#blob-payload).
+
+**Circuit constraints:**
+
+1. `1 <= batch_size <= BATCH_SIZE_MAX`.
+2. Each signer SNARK verifies under public inputs `(R, petition_id, predicate_hash, class_index, class_tag_i, slot, nullifier_i, identity_tag_i)`.
+3. `nullifier_i` and `identity_tag_i` (`i in [0, batch_size)`) are pairwise distinct.
+4. `nullifier_i` is non-member of `prior_running_root`; `identity_tag_i` of `prior_identity_tag_set_root`.
+5. `leaf_i = Poseidon1(DOMAIN_LEAF, nullifier_i, class_tag_i)` is strictly increasing in `i`.
+6. `new_running_root` and `new_identity_tag_set_root` result from inserting `leaf_i` and `identity_tag_i` (respectively) into the prior roots in this order.
+7. `new_leaf_count = prior_leaf_count + batch_size`.
+8. `batch_versioned_hash` opens at canonical evaluation points to BLS12-381 field elements decoding under [Blob Payload](#blob-payload) to `(nullifier_i, identity_tag_i, class_tag_i)` for `i in [0, batch_size)`; positions in `[batch_size, BATCH_SIZE_MAX)` decode to `(0, 0, 0)`. Cross-field binding: each in-circuit BN254 scalar has a big-endian 32-byte decomposition, byte-range-checked, equal to the corresponding BLS12-381 field element.
+
+### Resolution SNARK
+
+UltraHonk; zero-knowledge.
+
+**Public inputs (ordered):** `predicate_hash`, `R`, `running_root`, `leaf_count`, `class_set`, `class_thresholds`, `b`, `b_per_class`.
+
+**Private inputs:** leaf set `L = {leaf_1, ..., leaf_{leaf_count}}` underlying `running_root`; IMT membership proof per leaf; the witness pair `(nullifier_j, class_tag_j)` with `leaf_j = Poseidon1(DOMAIN_LEAF, nullifier_j, class_tag_j)`.
+
+**Circuit constraints:**
+
+1. `|L| = leaf_count`.
+2. `leaf_j` are pairwise distinct.
+3. Each `leaf_j` opens `running_root` under the IMT membership proof.
+4. `leaf_j = Poseidon1(DOMAIN_LEAF, nullifier_j, class_tag_j)` with the witnessed pair.
+5. `class_set` is strictly increasing.
+6. For `i in [0, |class_set|)`: `count_i = card{ j in [1, leaf_count] : class_tag_j = class_set[i] }`; `b_per_class[i] = 1` iff `count_i >= class_thresholds[i]`.
+7. `b = AND_i b_per_class[i]`.
+
+## Security Model
+
+### Threat Model
+
+Adversary capabilities:
+
+- Passive observation of L1 indefinitely, the blob carrier during the EIP-4844 retention window, and any voluntary blob archive thereafter.
+- Compelled key disclosure of any non-signer party (Organizer, Relayer, Resolver, Disputant, archiver).
+- Compelled key disclosure or device compromise of a signer, yielding `(identity_secret, attr_vector, RI Merkle path, s_curr, t, caterpillar, chain_root)` before or after the ratchet for slot `s_slot`.
+- Cross-petition correlation against any observable, including predicate-match intersections.
+- Sybil enrolment of multiple RI identities.
+
+Honest-party assumptions: Poseidon1 sponge security and UltraHonk soundness; EIP-4844 blob commitment binding; L1 censorship-resistant inclusion and finality; permissionless Relayer entry such that Signers can resubmit on Relayer-side censorship; Sybil resistance from RI.
+
+Out of scope: network transport anonymity beyond what Tor or an equivalent provides; real-time device compromise before the chain advances past `s_slot`; forensic recovery of overwritten storage on commodity media without `TRIM`.
+
+### Guarantees
+
+- **Per-petition forward secrecy.** An adversary holding audit-time runtime state, `identity_secret`, `attr_vector`, the RI Merkle path, and the full blob and L1 archives recovers `v_{k'}`, `s_{k'}`, or any value computationally non-trivial in `v_{k'}` (including the slot-`k'` nullifier and identity tag) for any slot `k' < t` with advantage at most `(t - k') * eps_sponge`, under the Poseidon1-sponge PRG assumption.
+- **Signer-level unlinkability.** For petitions `X1`, `X2` and records `r_1 in batch_{X1}`, `r_2 in batch_{X2}`, the adversary's advantage in deciding "same signer" exceeds `1/k - negl` only when it holds at least one of `v_{slot(X1)}` or `v_{slot(X2)}`, where `k` is the cardinality of Signers in `R` whose `attr_vector` satisfies both predicates and matches each petition's `class_tag`.
+- **One signature per RI leaf per petition.** For petition `X` and RI leaf `L_RI`, at most one record in `running_root` derives from `L_RI` after batching and dispute resolution.
+- **Outcome verifiability.** A verifier holding L1 chain state, the SRS identified by `srs_hash`, and the Poseidon1 parameter set re-verifies the resolution SNARK, confirming `b` and `b_per_class`.
+- **In-window dispute soundness.** A batch's contribution to `running_root` is removed only when the disputant produces valid KZG openings against `batch_versioned_hash` and evidence satisfying one of the enumerated violation predicates.
+- **Domain separation.** Reuse across petitions or deployments is rejected: `petition_id` derivation binds `chain_id` and `registry_address`, and each signer SNARK exposes `(petition_id, slot, class_tag, nullifier, identity_tag)` as public inputs.
+
+### Observability
+
+| Party | What it sees during a normal signing |
+|-------|--------------------------------------|
+| Organizer | Petition's public parameters and the on-chain bounty escrow |
+| RI credential operator | Per-RI-identity attribute commitments and the enrollment trail under `R` |
+| Signer | Their own `identity_secret`, `attr_vector`, RI Merkle path, FSRT runtime state, derived `(nullifier, identity_tag, class_tag)` values |
+| Relayer (at the anonymous-transport exit boundary) | The signer SNARK and the `(nullifier, identity_tag, class_tag)` tuple per submission; the resulting batch SNARK and blob payload contents; the relayer's own network origin |
+| Anonymous-transport peer (Tor or equivalent) | Entry peer: signer network origin only. Exit peer: signer SNARK and tuple delivered to the relayer. |
+| Disputant, Resolver | Public blob contents (within retention window or from voluntary archive) |
+| Ethereum observer | Batch SNARK public inputs; resolution SNARK public inputs; petition record fields |
+
+### Limitations and Shortcuts (PoC Scope)
+
+| Concern | Mitigation / Production Path |
+|---------|------------------------------|
+| Forward-secrecy bound assumes ideal storage erasure | Hardware-backed secure storage (Secure Enclave, TPM, HSM) for `s_curr`, `t`, `attr_version`, and the caterpillar frontier. |
+| Network-layer correlation at the relayer | Signer transport over Tor; submission paths SHOULD NOT use a transport-layer identifier (Tor circuit, VPN session) stable across petitions. |
+| Multi-device signing under one RI identity | Each device runs a fresh enrollment with a distinct `chain_root` and a new `attr_hash` leaf under an incremented `attr_version`. Signer wallets MUST refuse to export `s_curr`, `caterpillar`, or `t`. |
+| State-level builder censorship | FOCIL (EIP-7805); builder-pool diversity and direct-L1 submission. |
+| Predicate breadth and anonymity-set sizing | Deployment policy SHOULD enforce a minimum match count (e.g., `k >= 100`). |
+| Blob retention beyond 4096 epochs | Resolvers SHOULD archive blob payloads for petitions they intend to resolve. |
+
+## Terminology
+
+| Term | Definition |
+|------|------------|
+| Class | Value in `class_set` partitioning signatures for threshold accounting (e.g., an EU member state for an ECI petition). |
+| Outcome bits | `b` and `b_per_class` emitted by the resolution SNARK. |
+
+## References
+
+### Normative
+
+- [BCP 14 / RFC 2119](https://www.rfc-editor.org/rfc/rfc2119), [RFC 8174](https://www.rfc-editor.org/rfc/rfc8174)
+- [EIP-4844: Shard Blob Transactions](https://eips.ethereum.org/EIPS/eip-4844)
+- [EIP-7805: Fork-Choice enforced Inclusion Lists (FOCIL)](https://eips.ethereum.org/EIPS/eip-7805)
+- [Grassi, Khovratovich, Rechberger, Roy, Schofnegger, "Poseidon: A New Hash Function for Zero-Knowledge Proof Systems", USENIX Security 2021](https://eprint.iacr.org/2019/458)
+- [Bellare and Yee, "Forward-Security in Private-Key Cryptography", CT-RSA 2003](https://eprint.iacr.org/2001/035)
+- [Szydlo, "Merkle Tree Traversal in Log Space and Time", EUROCRYPT 2004](https://iacr.org/archive/eurocrypt2004/30270536/szydlo-loglog.pdf)
+- [Aztec Labs, "UltraHonk", Barretenberg](https://github.com/AztecProtocol/barretenberg)
+- [Barreto and Naehrig, "Pairing-Friendly Elliptic Curves of Prime Order", SAC 2005](https://eprint.iacr.org/2005/133)
+- [NIST FIPS PUB 202, "SHA-3 Standard"](https://doi.org/10.6028/NIST.FIPS.202)
+- [ResilientIdentity Protocol Specification](../../private-identity/resilient-private-identity/SPEC.md)
+
+### Informative
+
+- [Aztec Network, "Indexed Merkle Trees"](https://docs.aztec.network/aztec/concepts/storage/trees/indexed_merkle_tree)
+- [Privacy and Scaling Explorations, "OpenAC: Open Design for Transparent and Lightweight Anonymous Credentials", zkID Working Group, 2024](https://eprint.iacr.org/2026/251)


### PR DESCRIPTION
## Resilient Civic Participation: protocol specification

Draft SPEC.md for the Resilient Civic Participation PoC. Petitions anchor per-petition state in an on-chain IMT, publish per-signature records on EIP-4844 blobs, and resolve via a single SNARK once the dispute window closes. Signers advance a Forward-Secure Ratchet Tree past each signed slot for per-petition forward secrecy.

Covers participants, lifecycle, signer/batch/resolution SNARKs, dispute predicates, threat model, observability, and PoC-scope limitations.